### PR TITLE
Чиню падение туннеля при подключении и пару связанных багов

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -136,7 +136,6 @@ jobs:
           GOARCH=arm64 \
           CC="$TOOLCHAIN/aarch64-linux-android${ANDROID_MIN_API}-clang" \
             go build \
-              -buildmode=c-shared \
               -trimpath \
               -ldflags="-s -w -checklinkname=0" \
               -o ../app/src/main/jniLibs/arm64-v8a/libclient.so \
@@ -152,7 +151,6 @@ jobs:
           GOARM=7 \
           CC="$TOOLCHAIN/armv7a-linux-androideabi${ANDROID_MIN_API}-clang" \
             go build \
-              -buildmode=c-shared \
               -trimpath \
               -ldflags="-s -w -checklinkname=0" \
               -o ../app/src/main/jniLibs/armeabi-v7a/libclient.so \
@@ -167,7 +165,6 @@ jobs:
           GOARCH=amd64 \
           CC="$TOOLCHAIN/x86_64-linux-android${ANDROID_MIN_API}-clang" \
             go build \
-              -buildmode=c-shared \
               -trimpath \
               -ldflags="-s -w -checklinkname=0" \
               -o ../app/src/main/jniLibs/x86_64/libclient.so \

--- a/app/src/main/java/com/wdtt/client/TunnelService.kt
+++ b/app/src/main/java/com/wdtt/client/TunnelService.kt
@@ -280,6 +280,12 @@ class TunnelService : Service() {
     private fun startStatsUpdater() {
         updateJob?.cancel()
         updateJob = TunnelManager.scope.launch(Dispatchers.Main) {
+            // Сторож следит за ПРОПАЖОЙ уже поднятого VPN-интерфейса, а не за его
+            // отсутствием во время подключения. Фаза установки туннеля (капча → VK-креды →
+            // WRAP → TURN/DTLS → выдача WireGuard-конфига) может занимать значительно больше
+            // времени, чем любое фиксированное окно, особенно при ручном обходе капчи, поэтому
+            // аварийно глушим туннель только если интерфейс был поднят и затем пропал/заменён.
+            var wasEverUp = false
             delay(1000)
             while (isActive) {
                 if (!TunnelManager.running.value && !isTunnelPaused) {
@@ -289,8 +295,9 @@ class TunnelService : Service() {
                 }
                 if (TunnelManager.running.value && !isTunnelPaused) {
                     val helper = WireGuardHelper(applicationContext)
-                    val startupWindow = System.currentTimeMillis() - TunnelManager.processStartedAtMs < 6000
-                    if (!startupWindow && !helper.isTunnelUp()) {
+                    if (helper.isTunnelUp()) {
+                        wasEverUp = true
+                    } else if (wasEverUp) {
                         Log.w("TunnelService", "Обнаружена пропажа или замена VPN-интерфейса! Экстренное выключение туннеля.")
                         stopTunnel()
                         break

--- a/app/src/main/java/com/wdtt/client/ui/DeployTab.kt
+++ b/app/src/main/java/com/wdtt/client/ui/DeployTab.kt
@@ -584,10 +584,11 @@ private suspend fun performDeploy(
         val passArg = if (mainPass.isNotBlank()) "-password $mainPass " else ""
         val adminArg = if (adminId.isNotBlank()) "-admin $adminId " else ""
         val botArg = if (botToken.isNotBlank()) "-bot-token $botToken " else ""
-        // ВНИМАНИЕ: wdtt-server не поддерживает флаг -dns (DNS захардкожен в server.go),
-        // передача -dns роняла сервис: "flag provided but not defined: -dns" → крах-луп.
-        // Не добавляем -dns в ExecStart, пока сервер не научится его принимать.
-        val args = "$passArg$adminArg$botArg".trim()
+        // -dns поддерживается сервером (server.go, флаг -dns). Передаём только при заданном
+        // значении; несколько адресов — через запятую. Пустые поля -> сервер берёт свой default.
+        val dnsValue = listOf(dns1, dns2).map { it.trim() }.filter { it.isNotEmpty() }.joinToString(",")
+        val dnsArg = if (dnsValue.isNotEmpty()) "-dns $dnsValue " else ""
+        val args = "$passArg$adminArg$botArg$dnsArg".trim()
 
         val scriptFile = File(context.cacheDir, "deploy.sh")
         val serverFile = File(context.cacheDir, "server")

--- a/app/src/main/java/com/wdtt/client/ui/DeployTab.kt
+++ b/app/src/main/java/com/wdtt/client/ui/DeployTab.kt
@@ -584,8 +584,10 @@ private suspend fun performDeploy(
         val passArg = if (mainPass.isNotBlank()) "-password $mainPass " else ""
         val adminArg = if (adminId.isNotBlank()) "-admin $adminId " else ""
         val botArg = if (botToken.isNotBlank()) "-bot-token $botToken " else ""
-        val dnsArg = "-dns ${if(dns1.isNotBlank()) dns1 else "1.1.1.1"}${if(dns2.isNotBlank()) ",$dns2" else ""} "
-        val args = "$passArg$adminArg$botArg$dnsArg".trim()
+        // ВНИМАНИЕ: wdtt-server не поддерживает флаг -dns (DNS захардкожен в server.go),
+        // передача -dns роняла сервис: "flag provided but not defined: -dns" → крах-луп.
+        // Не добавляем -dns в ExecStart, пока сервер не научится его принимать.
+        val args = "$passArg$adminArg$botArg".trim()
 
         val scriptFile = File(context.cacheDir, "deploy.sh")
         val serverFile = File(context.cacheDir, "server")

--- a/server.go
+++ b/server.go
@@ -49,10 +49,13 @@ const (
 	wgServerAddr          = "10.66.66.1"
 	wgServerCIDR          = wgServerAddr + "/24"
 	defaultInternalWGPort = 56001
-	dns                   = "1.1.1.1"
 	wgMTU                 = 1280
 	keepalive             = 25
 )
+
+// dns — DNS-серверы, прописываемые в WireGuard-конфиг клиента.
+// Значение по умолчанию переопределяется флагом -dns (несколько через запятую).
+var dns = "1.1.1.1"
 
 // ==================== База данных и Бот ====================
 
@@ -1311,7 +1314,12 @@ func main() {
 	mainPass := flag.String("password", "", "пароль владельца")
 	adminID := flag.String("admin", "", "Telegram Admin ID")
 	botToken := flag.String("bot-token", "", "Telegram Bot Token")
+	dnsFlag := flag.String("dns", dns, "DNS для клиента (можно несколько через запятую)")
 	flag.Parse()
+
+	if v := strings.TrimSpace(*dnsFlag); v != "" {
+		dns = v
+	}
 
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
 	log.Println("══════════════════════════════════════════")


### PR DESCRIPTION
Ловил проблему, что туннель не поднимается, и по ходу нашёл три бага —
по отдельности мелкие, но вместе делали подключение нерабочим. Все три тут.

**1. Native-клиент падал с segfault сразу при старте.**
Приложение запускает `libclient.so` как отдельный процесс через
ProcessBuilder, а в CI он собирался с `-buildmode=c-shared`, то есть как
shared library, а не исполняемый файл. На устройстве это видно сразу:

    $ libclient.so -h
    Segmentation fault
    $ readelf -h libclient.so  →  Type: DYN, Entry point: 0x0

Точки входа нет, запускать как процесс нечего — отсюда «значок мигнул и всё
погасло, в логах пусто». Убрал `-buildmode=c-shared` для всех ABI, теперь
собирается нормальный исполняемый файл. В `build_android_go.bat` всё уже было
правильно — расходился только GitHub Actions.

**2. Туннель сам себя убивал через 6 секунд после «Подключить».**
В `TunnelService` сторож решал, что если WireGuard-интерфейс не поднялся за
6 секунд от старта процесса — значит VPN пропал, и рубил туннель
(`Обнаружена пропажа или замена VPN-интерфейса`). Но за 6 секунд он подняться
и не может: сначала капча, креды VK, WRAP, TURN/DTLS, и только потом конфиг.
Особенно с ручной капчей. Переделал: сторож теперь срабатывает только если
интерфейс реально был поднят и потом пропал, а не пока идёт подключение.

**3. Деплой ронял сервер из-за флага `-dns`.**
Вкладка «Деплой» всегда дописывала в команду сервера `-dns 1.1.1.1,...`, а
`server.go` такого флага не знал (DNS был захардкожен), и сервис уходил в
рестарт-луп: `flag provided but not defined: -dns`. Поля DNS в деплое по сути
ничего не делали. Добавил флаг `-dns` на сервер (значение идёт в конфиг
клиента, можно несколько через запятую), а в деплое теперь шлю его только
если поле заполнено — пустое не ломает даже старый бинарник.


починил клодом собирал через actions в форке. После изменений внизу заработало соединение. Надеюсь поможет