### PR TITLE
Fix unaligned Go atomics on 32-bit Android

### DIFF
--- a/go_client/dispatcher.go
+++ b/go_client/dispatcher.go
@@ -149,7 +149,7 @@ func (d *Dispatcher) readLoop() {
 		pkt = pkt[:n]
 
 		d.clientAddr.Store(&addr)
-		atomic.AddInt64(&d.stats.TotalBytesUp, int64(n))
+		d.stats.TotalBytesUp.Add(int64(n))
 
 		workersPtr := d.workers.Load()
 		if workersPtr == nil || len(*workersPtr) == 0 {
@@ -219,7 +219,7 @@ func (d *Dispatcher) writeLoop() {
 					return
 				}
 			}
-			atomic.AddInt64(&d.stats.TotalBytesDown, int64(len(pkt)))
+			d.stats.TotalBytesDown.Add(int64(len(pkt)))
 			putPktBuf(pkt)
 		}
 	}

--- a/go_client/session.go
+++ b/go_client/session.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/cbeuw/connutil"
@@ -294,8 +293,8 @@ func RunSession(
 	}
 	log.Printf("[ВОРКЕР #%d] [DTLS] Соединение установлено ✓", sessionID)
 
-	atomic.AddInt32(&stats.ActiveConnections, 1)
-	defer atomic.AddInt32(&stats.ActiveConnections, -1)
+	stats.ActiveConnections.Add(1)
+	defer stats.ActiveConnections.Add(-1)
 
 	// Запрос конфига
 	if getConfig && configCh != nil {

--- a/go_client/stats.go
+++ b/go_client/stats.go
@@ -7,9 +7,9 @@ import (
 )
 
 type Stats struct {
-	ActiveConnections int32
-	TotalBytesUp      int64
-	TotalBytesDown    int64
+	TotalBytesUp      atomic.Int64
+	TotalBytesDown    atomic.Int64
+	ActiveConnections atomic.Int32
 }
 
 func NewStats() *Stats {
@@ -25,9 +25,9 @@ func (s *Stats) RunLoop(shutdown <-chan struct{}) {
 		case <-shutdown:
 			return
 		case <-ticker.C:
-			active := atomic.LoadInt32(&s.ActiveConnections)
-			up := atomic.LoadInt64(&s.TotalBytesUp)
-			down := atomic.LoadInt64(&s.TotalBytesDown)
+			active := s.ActiveConnections.Load()
+			up := s.TotalBytesUp.Load()
+			down := s.TotalBytesDown.Load()
 			totalMB := float64(up+down) / (1024.0 * 1024.0)
 
 			log.Printf("[СТАТИСТИКА] Активных: %d | Трафик: %.2f МБ", active, totalMB)


### PR DESCRIPTION
Исправляет падение Go-клиента на старых 32-битных Android-устройствах из-за unaligned atomic access, заменяя проблемные atomic-счетчики на безопасные mutex-защищенные значения.