### PR TITLE
Fix split tunnel mode semantics

### DIFF
--- a/app/src/main/java/com/wdtt/client/SettingsStore.kt
+++ b/app/src/main/java/com/wdtt/client/SettingsStore.kt
@@ -1,6 +1,8 @@
 package com.wdtt.client
 
 import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
 import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
@@ -13,10 +15,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-
-import android.os.Build
 
 class SettingsStore(context: Context) {
     private val appContext = context.applicationContext
@@ -77,6 +78,7 @@ class SettingsStore(context: Context) {
         
         // ═══ VPN Exclusions Mode ═══
         private val IS_WHITELIST = booleanPreferencesKey("is_whitelist")
+        private val SPLIT_TUNNEL_WHITELIST_MIGRATED = booleanPreferencesKey("split_tunnel_whitelist_migrated")
 
         // ═══ Theme Mode ═══
         private val THEME_MODE = stringPreferencesKey("theme_mode") // "system", "light", "dark"
@@ -120,6 +122,7 @@ class SettingsStore(context: Context) {
     init {
         CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
             migrateSecretsToKeystore()
+            migrateLegacyWhitelistMode()
         }
     }
 
@@ -469,6 +472,7 @@ class SettingsStore(context: Context) {
         dataStore.edit { prefs ->
             val profile = prefs[ACTIVE_PROFILE] ?: 0
             prefs[getProfileKey(EXCLUDED_APPS, profile)] = packages
+            prefs[SPLIT_TUNNEL_WHITELIST_MIGRATED] = true
         }
     }
     
@@ -545,6 +549,7 @@ class SettingsStore(context: Context) {
         dataStore.edit { prefs ->
             val profile = prefs[ACTIVE_PROFILE] ?: 0
             prefs[getProfileKey(IS_WHITELIST, profile)] = enabled
+            prefs[SPLIT_TUNNEL_WHITELIST_MIGRATED] = true
         }
     }
 
@@ -554,6 +559,7 @@ class SettingsStore(context: Context) {
             val profile = prefs[ACTIVE_PROFILE] ?: 0
             prefs[getProfileKey(EXCLUDED_APPS, profile)] = packages
             prefs[getProfileKey(IS_WHITELIST, profile)] = isWhitelist
+            prefs[SPLIT_TUNNEL_WHITELIST_MIGRATED] = true
         }
     }
 
@@ -567,6 +573,48 @@ class SettingsStore(context: Context) {
                 prefs.migrateSecret(getProfileKey(DEPLOY_BOT_TOKEN_ENCRYPTED, profile), getProfileKey(DEPLOY_BOT_TOKEN, profile))
             }
         }
+    }
+
+    suspend fun migrateLegacyWhitelistMode() {
+        val currentPrefs = dataStore.data.first()
+        if (currentPrefs[SPLIT_TUNNEL_WHITELIST_MIGRATED] == true) return
+
+        val hasLegacyWhitelist = (0..2).any { profile ->
+            currentPrefs[getProfileKey(IS_WHITELIST, profile)] == true
+        }
+        val installedApps = if (hasLegacyWhitelist) installedSplitTunnelPackages() else emptySet()
+        dataStore.edit { prefs ->
+            if (prefs[SPLIT_TUNNEL_WHITELIST_MIGRATED] == true) return@edit
+
+            for (profile in 0..2) {
+                val whitelistKey = getProfileKey(IS_WHITELIST, profile)
+                val appsKey = getProfileKey(EXCLUDED_APPS, profile)
+                if (prefs[whitelistKey] == true) {
+                    val legacyExcluded = prefs[appsKey]
+                        ?.split(",")
+                        ?.filter { it.isNotEmpty() }
+                        ?.toSet()
+                        ?: emptySet()
+                    prefs[appsKey] = (installedApps - legacyExcluded).sorted().joinToString(",")
+                }
+            }
+
+            prefs[SPLIT_TUNNEL_WHITELIST_MIGRATED] = true
+        }
+    }
+
+    private fun installedSplitTunnelPackages(): Set<String> {
+        return runCatching {
+            appContext.packageManager
+                .getInstalledApplications(PackageManager.GET_META_DATA)
+                .map { it.packageName }
+                .filter {
+                    it != appContext.packageName &&
+                        !it.contains("vkontakte") &&
+                        !it.contains("vk.calls")
+                }
+                .toSet()
+        }.getOrDefault(emptySet())
     }
 
     private fun readSecret(

--- a/app/src/main/java/com/wdtt/client/TunnelService.kt
+++ b/app/src/main/java/com/wdtt/client/TunnelService.kt
@@ -304,12 +304,16 @@ class TunnelService : Service() {
                 }
                 if (TunnelManager.running.value && !isTunnelPaused) {
                     val helper = WireGuardHelper(applicationContext)
-                    if (helper.isTunnelUp()) {
-                        wasEverUp = true
-                    } else if (wasEverUp) {
-                        Log.w("TunnelService", "Обнаружена пропажа или замена VPN-интерфейса! Экстренное выключение туннеля.")
-                        stopTunnel()
-                        break
+                    when (helper.watchdogState()) {
+                        WireGuardHelper.WatchdogState.UP -> wasEverUp = true
+                        WireGuardHelper.WatchdogState.DISABLED_BY_EMPTY_WHITELIST -> Unit
+                        WireGuardHelper.WatchdogState.DOWN -> {
+                            if (wasEverUp) {
+                                Log.w("TunnelService", "Обнаружена пропажа или замена VPN-интерфейса! Экстренное выключение туннеля.")
+                                stopTunnel()
+                                break
+                            }
+                        }
                     }
                 }
                 if (!isTunnelPaused) {

--- a/app/src/main/java/com/wdtt/client/WireGuardHelper.kt
+++ b/app/src/main/java/com/wdtt/client/WireGuardHelper.kt
@@ -22,13 +22,21 @@ class WireGuardHelper(context: Context) {
     private val backend = (appContext as WdttApplication).getBackend(context)
 
     private companion object {
+        const val EMPTY_WHITELIST_MESSAGE = "В режиме БС выберите хотя бы одно приложение"
         val wgMutex = Mutex()
         var sharedTunnel: WgTunnel? = null
+        var disabledByEmptyWhitelist = false
     }
 
     class WgTunnel : Tunnel {
         override fun getName() = "wdtt"
         override fun onStateChange(newState: Tunnel.State) {}
+    }
+
+    enum class WatchdogState {
+        UP,
+        DOWN,
+        DISABLED_BY_EMPTY_WHITELIST
     }
 
     suspend fun startTunnel(configString: String) = wgMutex.withLock {
@@ -42,16 +50,6 @@ class WireGuardHelper(context: Context) {
             }
 
             ensureGoBackendServiceStarted()
-
-            sharedTunnel?.let { existingTunnel ->
-                try {
-                    backend.setState(existingTunnel, Tunnel.State.DOWN, null)
-                } catch (e: Exception) {
-                    Log.w("WG", "Failed to stop previous tunnel before restart: ${e.readableMessage()}")
-                }
-                sharedTunnel = null
-                delay(150)
-            }
 
             val parsedConfig = Config.parse(ByteArrayInputStream(configString.toByteArray(Charsets.UTF_8)))
 
@@ -73,21 +71,29 @@ class WireGuardHelper(context: Context) {
             }
             builder.parsePrivateKey(parsedConfig.`interface`.keyPair.privateKey.toBase64())
 
-            // 1. Пакеты, которые всегда исключаются (наше приложение, ВК)
-            // 2. Получаю настройки пользователя
+            // WDTT and VK calls must stay outside the VPN transport path.
             val settingsStore = SettingsStore(appContext)
+            settingsStore.migrateLegacyWhitelistMode()
             val savedExcluded = settingsStore.excludedApps.first()
-            
+            val isWhitelist = settingsStore.isWhitelist.first()
             val userSelected = savedExcluded.split(",").filter { it.isNotEmpty() }.toSet()
+            val transportPackages = setOf(appContext.packageName, "com.vkontakte.android", "com.vk.calls")
 
-            // В обоих режимах (ЧС и БС) мы технически используем Blacklist (Checked = Excluded),
-            // так как пользователю удобнее логика "снимите галочку, чтобы приложение пошло в туннель".
-            // Разница только в описании и начальном состоянии списка (пустой/полный).
-            val excluded = mutableSetOf(appContext.packageName, "com.vkontakte.android", "com.vk.calls")
-            excluded.addAll(userSelected)
-            val installedExcluded = excluded.filter { it.isInstalledPackage() }.toSet()
-            if (installedExcluded.isNotEmpty()) {
-                builder.excludeApplications(installedExcluded)
+            if (isWhitelist) {
+                val installedIncluded = userSelected
+                    .filter { it !in transportPackages && it.isInstalledPackage() }
+                    .toSet()
+                if (installedIncluded.isEmpty()) {
+                    throw IllegalStateException(EMPTY_WHITELIST_MESSAGE)
+                }
+                builder.includeApplications(installedIncluded)
+            } else {
+                val excluded = transportPackages.toMutableSet()
+                excluded.addAll(userSelected)
+                val installedExcluded = excluded.filter { it.isInstalledPackage() }.toSet()
+                if (installedExcluded.isNotEmpty()) {
+                    builder.excludeApplications(installedExcluded)
+                }
             }
 
             val newInterface = builder.build()
@@ -109,11 +115,16 @@ class WireGuardHelper(context: Context) {
                 .addPeer(peerBuilder.build())
                 .build()
 
+            disabledByEmptyWhitelist = false
+            stopSharedTunnel("previous tunnel before restart")
             val nextTunnel = WgTunnel()
             setTunnelUpWithRetry(nextTunnel, finalConfig)
             sharedTunnel = nextTunnel
             Log.d("WG", "WireGuard tunnel started successfully")
         } catch (e: Exception) {
+            if (e.isEmptyWhitelistFailure()) {
+                throw e
+            }
             val detailed = "WireGuard start failed: ${e.readableMessage()}; ${configString.describeWireGuardConfig()}"
             Log.e("WG", detailed)
             e.printStackTrace()
@@ -123,26 +134,31 @@ class WireGuardHelper(context: Context) {
 
     suspend fun reloadTunnel() = wgMutex.withLock {
         withContext(Dispatchers.IO) {
-            val currentTunnel = sharedTunnel ?: return@withContext
             try {
                 val configFlow = TunnelManager.config.first() ?: return@withContext
-                backend.setState(currentTunnel, Tunnel.State.DOWN, null)
-                sharedTunnel = null
-                delay(150)
                 startTunnelLocked(configFlow)
                 Log.d("WG", "WireGuard tunnel reloaded for new exceptions")
             } catch (e: Exception) {
-                Log.e("WG", "Failed to reload WireGuard: ${e.readableMessage()}")
+                if (e.isEmptyWhitelistFailure()) {
+                    stopSharedTunnel("empty whitelist")
+                    disabledByEmptyWhitelist = true
+                    Log.d("WG", "WireGuard tunnel disabled for empty whitelist")
+                } else {
+                    Log.e("WG", "Failed to reload WireGuard: ${e.readableMessage()}")
+                }
             }
         }
     }
 
     suspend fun isTunnelUp(): Boolean = wgMutex.withLock {
-        val current = sharedTunnel ?: return false
-        return try {
-            backend.getState(current) == Tunnel.State.UP
-        } catch (e: Exception) {
-            false
+        isSharedTunnelUpLocked()
+    }
+
+    suspend fun watchdogState(): WatchdogState = wgMutex.withLock {
+        when {
+            disabledByEmptyWhitelist -> WatchdogState.DISABLED_BY_EMPTY_WHITELIST
+            isSharedTunnelUpLocked() -> WatchdogState.UP
+            else -> WatchdogState.DOWN
         }
     }
 
@@ -154,6 +170,7 @@ class WireGuardHelper(context: Context) {
                     sharedTunnel = null
                     Log.d("WG", "WireGuard tunnel stopped")
                 }
+                disabledByEmptyWhitelist = false
             } catch (e: Exception) {
                 Log.e("WG", "Failed to stop WireGuard: ${e.readableMessage()}")
             }
@@ -170,6 +187,18 @@ class WireGuardHelper(context: Context) {
             }
         }
         delay(300)
+    }
+
+    private suspend fun stopSharedTunnel(reason: String) {
+        sharedTunnel?.let { existingTunnel ->
+            try {
+                backend.setState(existingTunnel, Tunnel.State.DOWN, null)
+            } catch (e: Exception) {
+                Log.w("WG", "Failed to stop tunnel for $reason: ${e.readableMessage()}")
+            }
+            sharedTunnel = null
+            delay(150)
+        }
     }
 
     private suspend fun setTunnelUpWithRetry(nextTunnel: WgTunnel, finalConfig: Config) {
@@ -192,6 +221,19 @@ class WireGuardHelper(context: Context) {
     private fun Throwable.readableMessage(): String {
         val text = message ?: localizedMessage
         return if (text.isNullOrBlank()) this::class.java.simpleName else "${this::class.java.simpleName}: $text"
+    }
+
+    private fun Throwable.isEmptyWhitelistFailure(): Boolean {
+        return message?.contains(EMPTY_WHITELIST_MESSAGE) == true
+    }
+
+    private fun isSharedTunnelUpLocked(): Boolean {
+        val current = sharedTunnel ?: return false
+        return try {
+            backend.getState(current) == Tunnel.State.UP
+        } catch (e: Exception) {
+            false
+        }
     }
 
     private fun String.isInstalledPackage(): Boolean {

--- a/app/src/main/java/com/wdtt/client/ui/ExceptionsTab.kt
+++ b/app/src/main/java/com/wdtt/client/ui/ExceptionsTab.kt
@@ -60,6 +60,7 @@ fun ExceptionsTab() {
 
     var appsList by remember { mutableStateOf<List<AppItem>>(AppCache.cachedList ?: emptyList()) }
     var isLoading by remember { mutableStateOf(AppCache.cachedList == null) }
+    var isMigrationReady by remember { mutableStateOf(false) }
     var searchQuery by remember { mutableStateOf("") }
 
     val showSystemAppsOpt by settingsStore.showSystemApps.collectAsStateWithLifecycle(initialValue = null)
@@ -68,6 +69,11 @@ fun ExceptionsTab() {
 
     // Load Apps
     LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) {
+            settingsStore.migrateLegacyWhitelistMode()
+        }
+        isMigrationReady = true
+
         if (AppCache.cachedList != null) return@LaunchedEffect
         isLoading = true
         withContext(Dispatchers.IO) {
@@ -155,7 +161,7 @@ fun ExceptionsTab() {
                         color = MaterialTheme.colorScheme.onSurface
                     )
                     Text(
-                        if (isWhitelist) "БС: Неотмеченные приложения добавляются в туннель"
+                        if (isWhitelist) "БС: Выбранные приложения добавляются в туннель"
                         else "ЧС: Выбранные приложения исключаются из туннеля",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -164,23 +170,19 @@ fun ExceptionsTab() {
                     )
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    ModeChip("ЧС", !isWhitelist) {
+                    ModeChip("ЧС", !isWhitelist, enabled = isMigrationReady) {
                         if (isWhitelist) {
                             scope.launch {
-                                val all = appsList.map { it.packageName }.toSet()
-                                val inverted = all - selectedPackages
-                                settingsStore.saveExceptionsMode(inverted.joinToString(","), false)
+                                settingsStore.saveExceptionsMode("", false)
                                 delay(300)
                                 com.wdtt.client.TunnelManager.reloadWireGuard()
                             }
                         }
                     }
-                    ModeChip("БС", isWhitelist) {
+                    ModeChip("БС", isWhitelist, enabled = isMigrationReady) {
                         if (!isWhitelist) {
                             scope.launch {
-                                val all = appsList.map { it.packageName }.toSet()
-                                val inverted = all - selectedPackages
-                                settingsStore.saveExceptionsMode(inverted.joinToString(","), true)
+                                settingsStore.saveExceptionsMode("", true)
                                 delay(300)
                                 com.wdtt.client.TunnelManager.reloadWireGuard()
                             }
@@ -218,7 +220,7 @@ fun ExceptionsTab() {
         }
 
         // List
-        if (isLoading || showSystemAppsOpt == null) {
+        if (!isMigrationReady || isLoading || showSystemAppsOpt == null) {
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator()
             }
@@ -255,10 +257,11 @@ fun ExceptionsTab() {
 }
 
 @Composable
-private fun ModeChip(label: String, selected: Boolean, onClick: () -> Unit) {
+private fun ModeChip(label: String, selected: Boolean, enabled: Boolean = true, onClick: () -> Unit) {
     FilterChip(
         selected = selected,
         onClick = onClick,
+        enabled = enabled,
         label = {
             Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                 Text(


### PR DESCRIPTION
Исправляет режим БС как настоящий whitelist: выбранные приложения добавляются в туннель, а ЧС по-прежнему исключает выбранные приложения. При переключении режимов список выбора сбрасывается, чтобы оба режима начинались без отмеченных приложений.
https://github.com/amurcanov/proxy-turn-vk-android/issues/222