### PR TITLE
Fix Linux server UAPI listener build

### DIFF
--- a/app/src/main/assets/linux-server/net.go
+++ b/app/src/main/assets/linux-server/net.go
@@ -337,7 +337,13 @@ func startUserspaceWG(keys *wgKeys, wgPort int) (*device.Device, error) {
 	}
 
 	go func() {
-		uapi, err := ipc.UAPIListen(ifaceName)
+		uapiFile, err := ipc.UAPIOpen(ifaceName)
+		if err != nil {
+			return
+		}
+		defer uapiFile.Close()
+
+		uapi, err := ipc.UAPIListen(ifaceName, uapiFile)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Исправляет сборку Linux-сервера после обновления golang.zx2c4.com/wireguard: новый API ipc.UAPIListen требует предварительно открыть UAPI socket через ipc.UAPIOpen и передать полученный file handle. Без этого сервер не компилируется.