### PR TITLE
пофикшены логи серверная часть и тд тп 

### DIFF
--- a/app/src/main/assets/linux-server/net.go
+++ b/app/src/main/assets/linux-server/net.go
@@ -87,8 +87,6 @@ func statsLoop(ctx context.Context, configDir string) {
 			total := atomic.LoadInt64(&totalConns)
 			uptime := time.Since(serverStartTime)
 
-			// log.Printf убран чтобы не засорять логи  дублирующейся информацией
-
 			dbMutex.Lock()
 			numPasswords := len(db.Passwords)
 			numDevices := len(db.Devices)
@@ -97,6 +95,9 @@ func statsLoop(ctx context.Context, configDir string) {
 			uptimeStr := formatUptime(uptime)
 			downGB := float64(toC) / (1024 * 1024 * 1024)
 			upGB := float64(fromC) / (1024 * 1024 * 1024)
+
+			log.Printf("[СТАТ] Активных: %d | Всего соединений: %d | Uptime: %s | Получено: %.2f GB | Отправлено: %.2f GB | Паролей: %d | Устройств: %d",
+				active, total, uptimeStr, downGB, upGB, numPasswords, numDevices)
 
 			statsJSON, _ := json.Marshal(map[string]interface{}{
 				"active":    active,
@@ -391,7 +392,7 @@ PersistentKeepalive = %d`,
 }
 
 func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgDev *device.Device, keys *wgKeys) {
-	// 1. предотвсращаем утечку тута
+	// Добавлен defer для предотвращения утечки сокетов при ошибках на любом этапе функции
 	defer clientConn.Close()
 
 	atomic.AddInt64(&totalConns, 1)
@@ -401,13 +402,13 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 
 	dtlsConn, ok := clientConn.(*dtls.Conn)
 	if !ok {
-		return // Ранее сокет оставался открытым, теперь закроется благодаря defer
+		return 
 	}
 
 	hctx, hcancel := context.WithTimeout(ctx, 30*time.Second)
 	if err := dtlsConn.HandshakeContext(hctx); err != nil {
 		hcancel()
-		return // Ранее сокет оставался открытым, теперь закроется благодаря defer
+		return 
 	}
 	hcancel()
 
@@ -675,4 +676,9 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 	}()
 
 	proxyWg.Wait()
+
+	// Добавлен финальный сброс статистики после завершения работы всех прокси-горутин
+	if connPassword != "" && !connIsMainPass {
+		flushStats()
+	}
 }

--- a/app/src/main/assets/linux-server/net.go
+++ b/app/src/main/assets/linux-server/net.go
@@ -71,8 +71,11 @@ var (
 func statsLoop(ctx context.Context, configDir string) {
 	serverStartTime = time.Now()
 	statsFile := filepath.Join(configDir, "server.log")
-	ticker := time.NewTicker(10 * time.Second)
+	
+	// интервал с 10 секунд на 1 минуту, чтобы снизить нагрузку на диск и процессор 
+	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
+	
 	for {
 		select {
 		case <-ctx.Done():
@@ -84,13 +87,8 @@ func statsLoop(ctx context.Context, configDir string) {
 			total := atomic.LoadInt64(&totalConns)
 			uptime := time.Since(serverStartTime)
 
-			log.Printf("[СТАТ] Активных: %d | Всего: %d | NAT: %s | ↑%.2f МБ | ↓%.2f МБ",
-				active, total, natType,
-				float64(fromC)/1024/1024,
-				float64(toC)/1024/1024,
-			)
+			// log.Printf убран чтобы не засорять логи  дублирующейся информацией
 
-			
 			dbMutex.Lock()
 			numPasswords := len(db.Passwords)
 			numDevices := len(db.Devices)

--- a/app/src/main/assets/linux-server/net.go
+++ b/app/src/main/assets/linux-server/net.go
@@ -391,6 +391,9 @@ PersistentKeepalive = %d`,
 }
 
 func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgDev *device.Device, keys *wgKeys) {
+	// 1. предотвсращаем утечку тута
+	defer clientConn.Close()
+
 	atomic.AddInt64(&totalConns, 1)
 
 	var connPassword string
@@ -398,13 +401,13 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 
 	dtlsConn, ok := clientConn.(*dtls.Conn)
 	if !ok {
-		return
+		return // Ранее сокет оставался открытым, теперь закроется благодаря defer
 	}
 
 	hctx, hcancel := context.WithTimeout(ctx, 30*time.Second)
 	if err := dtlsConn.HandshakeContext(hctx); err != nil {
 		hcancel()
-		return
+		return // Ранее сокет оставался открытым, теперь закроется благодаря defer
 	}
 	hcancel()
 
@@ -538,13 +541,10 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 		wgConn.SetDeadline(time.Now())
 	})
 
-	// Локальные счетчики трафика для текущей сессии
 	var localUpBytes int64
 	var localDownBytes int64
 
-	// Функция сброса локальной статистики в глобальную БД
 	flushStats := func() bool {
-		// Атомарно забираем накопленные байты и сбрасываем локальные счетчики в 0
 		up := atomic.SwapInt64(&localUpBytes, 0)
 		down := atomic.SwapInt64(&localDownBytes, 0)
 
@@ -553,7 +553,6 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 
 		e, ok := db.Passwords[connPassword]
 		if !ok || e == nil || isPasswordExpired(e) || e.IsDeactivated {
-			// Если пароль больше не валиден (истек/удален), сигнализируем о необходимости закрыть соединение
 			return false
 		}
 
@@ -565,22 +564,19 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 	var proxyWg sync.WaitGroup
 	proxyWg.Add(2)
 
-	// Запускаем горутину периодического сброса статистики, только если это не мастер-пароль
 	if connPassword != "" && !connIsMainPass {
 		proxyWg.Add(1)
 		go func() {
 			defer proxyWg.Done()
-			ticker := time.NewTicker(5 * time.Second) // Интервал обновления базы данных
+			ticker := time.NewTicker(5 * time.Second)
 			defer ticker.Stop()
 
 			for {
 				select {
 				case <-pctx.Done():
-					// Перед выходом осуществляем финальный сброс оставшейся статистики
 					flushStats()
 					return
 				case <-ticker.C:
-					// Сбрасываем статистику. Если сессия невалидна, инициируем отключение
 					if !flushStats() {
 						pcancel()
 						return
@@ -613,7 +609,6 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 			}
 			atomic.AddInt64(&totalBytesFromClient, int64(nn))
 			
-			// Локальный атомарный инкремент без использования мьютекса
 			if connPassword != "" && !connIsMainPass {
 				atomic.AddInt64(&localUpBytes, int64(nn))
 			}
@@ -649,7 +644,6 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 			}
 			atomic.AddInt64(&totalBytesToClient, int64(nn))
 			
-			// Локальный атомарный инкремент без использования мьютекса
 			if connPassword != "" && !connIsMainPass {
 				atomic.AddInt64(&localDownBytes, int64(nn))
 			}

--- a/app/src/main/assets/linux-server/net.go
+++ b/app/src/main/assets/linux-server/net.go
@@ -441,7 +441,6 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 
 		dbMutex.Lock()
 
-		
 		isMainPass := password != "" && password == db.MainPassword
 		entry, isGenPass := db.Passwords[password]
 		valid := isMainPass || (isGenPass && !isPasswordExpired(entry))
@@ -451,7 +450,6 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 			log.Printf("[WG] Отказ: пароль %s деактивирован, запрос от %s", maskPassword(password), deviceID)
 			dbMutex.Unlock()
 		} else if valid && isGenPass && entry.DeviceID != "" && entry.DeviceID != deviceID {
-			
 			clientConn.Write([]byte("DENIED:device_mismatch"))
 			log.Printf("[WG] Отказ: пароль %s привязан к %s, запрос от %s", maskPassword(password), entry.DeviceID, deviceID)
 			dbMutex.Unlock()
@@ -459,7 +457,6 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 			connPassword = password
 			connIsMainPass = isMainPass
 
-			
 			if isGenPass && entry.DeviceID == "" {
 				entry.DeviceID = deviceID
 				saveDB()
@@ -519,7 +516,6 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 		firstPacket = buf[:n]
 	}
 
-	
 	wgConn, err := net.Dial("udp", wgEndpoint)
 	if err != nil {
 		return
@@ -544,10 +540,59 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 		wgConn.SetDeadline(time.Now())
 	})
 
+	// Локальные счетчики трафика для текущей сессии
+	var localUpBytes int64
+	var localDownBytes int64
+
+	// Функция сброса локальной статистики в глобальную БД
+	flushStats := func() bool {
+		// Атомарно забираем накопленные байты и сбрасываем локальные счетчики в 0
+		up := atomic.SwapInt64(&localUpBytes, 0)
+		down := atomic.SwapInt64(&localDownBytes, 0)
+
+		dbMutex.Lock()
+		defer dbMutex.Unlock()
+
+		e, ok := db.Passwords[connPassword]
+		if !ok || e == nil || isPasswordExpired(e) || e.IsDeactivated {
+			// Если пароль больше не валиден (истек/удален), сигнализируем о необходимости закрыть соединение
+			return false
+		}
+
+		e.UpBytes += up
+		e.DownBytes += down
+		return true
+	}
+
 	var proxyWg sync.WaitGroup
 	proxyWg.Add(2)
 
-	
+	// Запускаем горутину периодического сброса статистики, только если это не мастер-пароль
+	if connPassword != "" && !connIsMainPass {
+		proxyWg.Add(1)
+		go func() {
+			defer proxyWg.Done()
+			ticker := time.NewTicker(5 * time.Second) // Интервал обновления базы данных
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-pctx.Done():
+					// Перед выходом осуществляем финальный сброс оставшейся статистики
+					flushStats()
+					return
+				case <-ticker.C:
+					// Сбрасываем статистику. Если сессия невалидна, инициируем отключение
+					if !flushStats() {
+						pcancel()
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	// Направление: Клиент -> WireGuard (Upload)
 	go func() {
 		defer proxyWg.Done()
 		defer pcancel()
@@ -570,23 +615,18 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 			}
 			atomic.AddInt64(&totalBytesFromClient, int64(nn))
 			
+			// Локальный атомарный инкремент без использования мьютекса
 			if connPassword != "" && !connIsMainPass {
-				dbMutex.Lock()
-				e, ok := db.Passwords[connPassword]
-				if !ok || e == nil || isPasswordExpired(e) || e.IsDeactivated {
-					dbMutex.Unlock()
-					return
-				}
-				e.UpBytes += int64(nn)
-				dbMutex.Unlock()
+				atomic.AddInt64(&localUpBytes, int64(nn))
 			}
+
 			if _, err := wgConn.Write((*b)[:nn]); err != nil {
 				return
 			}
 		}
 	}()
 
-	
+	// Направление: WireGuard -> Клиент (Download)
 	go func() {
 		defer proxyWg.Done()
 		defer pcancel()
@@ -611,16 +651,11 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 			}
 			atomic.AddInt64(&totalBytesToClient, int64(nn))
 			
+			// Локальный атомарный инкремент без использования мьютекса
 			if connPassword != "" && !connIsMainPass {
-				dbMutex.Lock()
-				e, ok := db.Passwords[connPassword]
-				if !ok || e == nil || isPasswordExpired(e) || e.IsDeactivated {
-					dbMutex.Unlock()
-					return
-				}
-				e.DownBytes += int64(nn)
-				dbMutex.Unlock()
+				atomic.AddInt64(&localDownBytes, int64(nn))
 			}
+
 			if _, err := clientConn.Write((*b)[:nn]); err != nil {
 				return
 			}

--- a/app/src/main/assets/linux-server/net.go
+++ b/app/src/main/assets/linux-server/net.go
@@ -586,19 +586,29 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 		}()
 	}
 
-	// Направление: Клиент -> WireGuard (Upload)
+// Направление: Клиент -> WireGuard (Upload)
 	go func() {
 		defer proxyWg.Done()
 		defer pcancel()
 		b := getBuf()
 		defer putBuf(b)
+		
+		var lastDeadlineUpdate time.Time
+
 		for {
 			select {
 			case <-pctx.Done():
 				return
 			default:
 			}
-			clientConn.SetReadDeadline(time.Now().Add(30 * time.Minute))
+			
+			// Вызываем дедлайн только раз в 15 секунд, а не на каждый пакет
+			now := time.Now()
+			if now.Sub(lastDeadlineUpdate) > 15*time.Second {
+				clientConn.SetReadDeadline(now.Add(30 * time.Minute))
+				lastDeadlineUpdate = now
+			}
+
 			nn, err := clientConn.Read(*b)
 			if err != nil {
 				return
@@ -619,19 +629,29 @@ func handleConn(ctx context.Context, clientConn net.Conn, wgEndpoint string, wgD
 		}
 	}()
 
-	// Направление: WireGuard -> Клиент (Download)
+// Направление: WireGuard -> Клиент (Download)
 	go func() {
 		defer proxyWg.Done()
 		defer pcancel()
 		b := getBuf()
 		defer putBuf(b)
+
+		var lastDeadlineUpdate time.Time
+
 		for {
 			select {
 			case <-pctx.Done():
 				return
 			default:
 			}
-			wgConn.SetReadDeadline(time.Now().Add(30 * time.Minute))
+
+			// Вызываем дедлайн только раз в 15 секунд
+			now := time.Now()
+			if now.Sub(lastDeadlineUpdate) > 15*time.Second {
+				wgConn.SetReadDeadline(now.Add(30 * time.Minute))
+				lastDeadlineUpdate = now
+			}
+
 			nn, err := wgConn.Read(*b)
 			if err != nil {
 				if isNetTimeout(err) {

--- a/app/src/main/assets/linux-server/obfs.go
+++ b/app/src/main/assets/linux-server/obfs.go
@@ -90,6 +90,14 @@ func obfsBuildNonceInto(dst *[12]byte, ssrc uint32, seq uint16, ts uint32) {
 	binary.BigEndian.PutUint32(dst[8:12], ts)
 }
 
+func obfsBuildNonce(ssrc uint32, seq uint16, ts uint32) []byte {
+	n := make([]byte, 12)
+	var tmp [12]byte
+	obfsBuildNonceInto(&tmp, ssrc, seq, ts)
+	copy(n, tmp[:])
+	return n
+}
+
 func obfsWrapWireLen(payloadLen int, cfg *ObfsConfig) int {
 	pad := cfg.PaddingMax
 	if pad < 1 {

--- a/app/src/main/assets/linux-server/obfs.go
+++ b/app/src/main/assets/linux-server/obfs.go
@@ -57,11 +57,9 @@ type ObfsConfig struct {
 }
 
 type ObfsState struct {
-	mu      sync.Mutex
 	initSeq uint16
 	initTs  uint32
-	count   uint64
-	rng     uint64 // Быстрый неблокирующий PRNG (Xorshift64)
+	count   uint64 // Поле обновляется атомарно через sync/atomic
 }
 
 func NewObfsConfig() *ObfsConfig {
@@ -75,19 +73,12 @@ func NewObfsConfig() *ObfsConfig {
 }
 
 func NewObfsState() *ObfsState {
-	var buf [14]byte // 6 байт для seq/ts + 8 байт для инициализации PRNG
+	var buf [6]byte
 	_, _ = rand.Read(buf[:])
-	
-	seed := binary.BigEndian.Uint64(buf[6:14])
-	if seed == 0 {
-		seed = 0xdeadbeef10decaf1 // сид для Xorshift не должен быть равен 0
-	}
-
 	return &ObfsState{
 		initSeq: binary.BigEndian.Uint16(buf[0:2]),
 		initTs:  binary.BigEndian.Uint32(buf[2:6]),
 		count:   0,
-		rng:     seed,
 	}
 }
 
@@ -107,28 +98,29 @@ func obfsWrapWireLen(payloadLen int, cfg *ObfsConfig) int {
 	return 12 + payloadLen + chacha20poly1305.Overhead + pad
 }
 
+func obfsMix64(v uint64) uint64 {
+	x := (v + 0x9e3779b97f4a7c15) ^ 0xbf58476d1ce4e5b9
+	x ^= x >> 30
+	x *= 0xbf58476d1ce4e5b9
+	x ^= x >> 27
+	x *= 0x94d049bb133111eb
+	x ^= x >> 31
+	return x
+}
+
 func obfsWrapPacketInto(dst []byte, aead cipher.AEAD, payload []byte, cfg *ObfsConfig, state *ObfsState) (int, error) {
 	if len(payload) == 0 {
 		return 0, errors.New("obfs: empty payload")
 	}
-	
-	state.mu.Lock()
-	c := state.count
-	state.count++
-	
-	// Один шаг Xorshift64 под существующим локом
-	x := state.rng
-	x ^= x << 13
-	x ^= x >> 7
-	x ^= x << 17
-	state.rng = x
-	state.mu.Unlock()
 
+	c := atomic.AddUint64(&state.count, 1) - 1
 	seq := state.initSeq + uint16(c)
 	ts := state.initTs + uint32(c)*960 + uint32(c>>16)
 
 	padRand := 0
+	x := uint64(0)
 	if cfg.PaddingMax > 0 {
+		x = obfsMix64(c)
 		padRand = int(x % uint64(cfg.PaddingMax))
 	}
 	padTotal := padRand + 1
@@ -147,17 +139,10 @@ func obfsWrapPacketInto(dst []byte, aead cipher.AEAD, payload []byte, cfg *ObfsC
 	obfsBuildNonceInto(&nonce, cfg.SSRC, seq, ts)
 	sealed := aead.Seal(dst[12:12], nonce[:], payload, dst[:12])
 	padStart := 12 + len(sealed)
-	
-	// Быстрое заполнение padding байтами из PRNG без аллокаций
+
 	if padRand > 0 {
-		localRNG := x
 		for i := 0; i < padRand; i++ {
-			if i%8 == 0 && i > 0 {
-				localRNG ^= localRNG << 13
-				localRNG ^= localRNG >> 7
-				localRNG ^= localRNG << 17
-			}
-			dst[padStart+i] = byte(localRNG >> ((i % 8) * 8))
+			dst[padStart+i] = byte(x >> ((i % 8) * 8))
 		}
 	}
 	dst[outLen-1] = byte(padTotal)
@@ -255,7 +240,7 @@ type wrapPacketConn struct {
 	inner     net.PacketConn
 	keys      *wrapKeyStore
 	key       []byte
-	aead      cipher.AEAD 
+	aead      cipher.AEAD
 	selected  int32
 	authLog   int32
 	obfsCfg   *ObfsConfig
@@ -283,7 +268,7 @@ func (c *wrapPacketConn) ReadFrom(p []byte) (int, net.Addr, error) {
 			return 0, addr, err
 		}
 		if n > 0 && (buf[0] == 0x00 || buf[0] == 0x16) {
-			continue 
+			continue
 		}
 		break
 	}
@@ -309,7 +294,7 @@ func (c *wrapPacketConn) ReadFrom(p []byte) (int, net.Addr, error) {
 		c.key = key
 		c.aead = aead
 		c.obfsCfg = NewObfsConfig()
-		
+
 		if len(raw) > 1 {
 			c.obfsCfg.PayloadType = raw[1] & 0x7F
 		}

--- a/app/src/main/assets/linux-server/obfs.go
+++ b/app/src/main/assets/linux-server/obfs.go
@@ -157,6 +157,22 @@ func obfsWrapPacketInto(dst []byte, aead cipher.AEAD, payload []byte, cfg *ObfsC
 	return outLen, nil
 }
 
+func obfsWrapPacket(key, payload []byte, cfg *ObfsConfig, state *ObfsState) ([]byte, error) {
+	if len(key) != wrapKeyLen {
+		return nil, fmt.Errorf("obfs: key must be %d bytes (got %d)", wrapKeyLen, len(key))
+	}
+	aead, err := getAEAD(key)
+	if err != nil {
+		return nil, fmt.Errorf("obfs: cipher init: %w", err)
+	}
+	out := make([]byte, obfsWrapWireLen(len(payload), cfg))
+	n, err := obfsWrapPacketInto(out, aead, payload, cfg, state)
+	if err != nil {
+		return nil, err
+	}
+	return out[:n], nil
+}
+
 func obfsUnwrapPacketAEAD(aead cipher.AEAD, wire, dst []byte) (int, error) {
 	if len(wire) < 13 {
 		return 0, errors.New("obfs: packet too short")

--- a/app/src/main/assets/linux-server/obfs.go
+++ b/app/src/main/assets/linux-server/obfs.go
@@ -1,5 +1,3 @@
-
-
 package main
 
 import (
@@ -28,6 +26,14 @@ const (
 
 var aeadCache sync.Map
 
+// Локальный пул буферов для чтения, чтобы не аллоцировать память на каждый пакет
+var obfsBufPool = sync.Pool{
+	New: func() interface{} {
+		b := make([]byte, 2048)
+		return &b
+	},
+}
+
 func getAEAD(key []byte) (cipher.AEAD, error) {
 	if len(key) != wrapKeyLen {
 		return nil, fmt.Errorf("obfs: key must be %d bytes", wrapKeyLen)
@@ -55,11 +61,12 @@ type ObfsState struct {
 	initSeq uint16
 	initTs  uint32
 	count   uint64
+	rng     uint64 // Быстрый неблокирующий PRNG (Xorshift64)
 }
 
 func NewObfsConfig() *ObfsConfig {
 	var buf [4]byte
-	rand.Read(buf[:])
+	_, _ = rand.Read(buf[:])
 	return &ObfsConfig{
 		SSRC:        binary.BigEndian.Uint32(buf[:]),
 		PayloadType: 111,
@@ -68,12 +75,19 @@ func NewObfsConfig() *ObfsConfig {
 }
 
 func NewObfsState() *ObfsState {
-	var buf [6]byte
-	rand.Read(buf[:])
+	var buf [14]byte // 6 байт для seq/ts + 8 байт для инициализации PRNG
+	_, _ = rand.Read(buf[:])
+	
+	seed := binary.BigEndian.Uint64(buf[6:14])
+	if seed == 0 {
+		seed = 0xdeadbeef10decaf1 // сид для Xorshift не должен быть равен 0
+	}
+
 	return &ObfsState{
 		initSeq: binary.BigEndian.Uint16(buf[0:2]),
 		initTs:  binary.BigEndian.Uint32(buf[2:6]),
 		count:   0,
+		rng:     seed,
 	}
 }
 
@@ -83,14 +97,6 @@ func obfsBuildNonceInto(dst *[12]byte, ssrc uint32, seq uint16, ts uint32) {
 	dst[6] = 0
 	dst[7] = 0
 	binary.BigEndian.PutUint32(dst[8:12], ts)
-}
-
-func obfsBuildNonce(ssrc uint32, seq uint16, ts uint32) []byte {
-	n := make([]byte, 12)
-	var tmp [12]byte
-	obfsBuildNonceInto(&tmp, ssrc, seq, ts)
-	copy(n, tmp[:])
-	return n
 }
 
 func obfsWrapWireLen(payloadLen int, cfg *ObfsConfig) int {
@@ -105,9 +111,17 @@ func obfsWrapPacketInto(dst []byte, aead cipher.AEAD, payload []byte, cfg *ObfsC
 	if len(payload) == 0 {
 		return 0, errors.New("obfs: empty payload")
 	}
+	
 	state.mu.Lock()
 	c := state.count
 	state.count++
+	
+	// Один шаг Xorshift64 под существующим локом
+	x := state.rng
+	x ^= x << 13
+	x ^= x >> 7
+	x ^= x << 17
+	state.rng = x
 	state.mu.Unlock()
 
 	seq := state.initSeq + uint16(c)
@@ -115,9 +129,7 @@ func obfsWrapPacketInto(dst []byte, aead cipher.AEAD, payload []byte, cfg *ObfsC
 
 	padRand := 0
 	if cfg.PaddingMax > 0 {
-		var rndBuf [1]byte
-		rand.Read(rndBuf[:])
-		padRand = int(rndBuf[0]) % cfg.PaddingMax
+		padRand = int(x % uint64(cfg.PaddingMax))
 	}
 	padTotal := padRand + 1
 	outLen := 12 + len(payload) + chacha20poly1305.Overhead + padTotal
@@ -135,27 +147,21 @@ func obfsWrapPacketInto(dst []byte, aead cipher.AEAD, payload []byte, cfg *ObfsC
 	obfsBuildNonceInto(&nonce, cfg.SSRC, seq, ts)
 	sealed := aead.Seal(dst[12:12], nonce[:], payload, dst[:12])
 	padStart := 12 + len(sealed)
+	
+	// Быстрое заполнение padding байтами из PRNG без аллокаций
 	if padRand > 0 {
-		rand.Read(dst[padStart : padStart+padRand])
+		localRNG := x
+		for i := 0; i < padRand; i++ {
+			if i%8 == 0 && i > 0 {
+				localRNG ^= localRNG << 13
+				localRNG ^= localRNG >> 7
+				localRNG ^= localRNG << 17
+			}
+			dst[padStart+i] = byte(localRNG >> ((i % 8) * 8))
+		}
 	}
 	dst[outLen-1] = byte(padTotal)
 	return outLen, nil
-}
-
-func obfsWrapPacket(key, payload []byte, cfg *ObfsConfig, state *ObfsState) ([]byte, error) {
-	if len(key) != wrapKeyLen {
-		return nil, fmt.Errorf("obfs: key must be %d bytes (got %d)", wrapKeyLen, len(key))
-	}
-	aead, err := getAEAD(key)
-	if err != nil {
-		return nil, fmt.Errorf("obfs: cipher init: %w", err)
-	}
-	out := make([]byte, obfsWrapWireLen(len(payload), cfg))
-	n, err := obfsWrapPacketInto(out, aead, payload, cfg, state)
-	if err != nil {
-		return nil, err
-	}
-	return out[:n], nil
 }
 
 func obfsUnwrapPacketAEAD(aead cipher.AEAD, wire, dst []byte) (int, error) {
@@ -255,45 +261,38 @@ type wrapPacketConn struct {
 	obfsCfg   *ObfsConfig
 	obfsWrite *ObfsState
 
-	
-	
-	
-	
 	rxMu  sync.Mutex
-	rxBuf []byte
 	txMu  sync.Mutex
 	txBuf []byte
 }
 
 func (c *wrapPacketConn) ReadFrom(p []byte) (int, net.Addr, error) {
-	c.rxMu.Lock()
-	defer c.rxMu.Unlock()
-
-	
-	need := len(p) + 80
-	if cap(c.rxBuf) < need {
-		c.rxBuf = make([]byte, need)
-	}
-	buf := c.rxBuf[:need]
+	// Получаем буфер из пула во временное пользование (вне мьютекса!)
+	bufPtr := obfsBufPool.Get().(*[]byte)
+	defer obfsBufPool.Put(bufPtr)
+	buf := *bufPtr
 
 	var n int
 	var addr net.Addr
 	var err error
-	var raw []byte
 
+	// Сетевое чтение происходит без блокировки rxMu
 	for {
 		n, addr, err = c.inner.ReadFrom(buf)
 		if err != nil {
 			return 0, addr, err
 		}
-		raw = buf[:n]
-
-		
-		if len(raw) > 0 && (raw[0] == 0x00 || raw[0] == 0x16) {
+		if n > 0 && (buf[0] == 0x00 || buf[0] == 0x16) {
 			continue 
 		}
 		break
 	}
+
+	raw := buf[:n]
+
+	// Блокируем только на короткие вычисления
+	c.rxMu.Lock()
+	defer c.rxMu.Unlock()
 
 	if atomic.LoadInt32(&c.selected) == 0 {
 		key, m, uErr := c.keys.Unwrap(raw, p)


### PR DESCRIPTION
Исправление утечки сокетов в defer clientConn.Close()  
при ошибке на любом этапе (DTLS handshake, чтение первого пакета, WRAP-ошибка) сокет клиента оставался открытым  
теперь исправленно


Интервал статистики: с 10 сек  на 1 минуту
Об этом просили, и теперь диск не будет засорятся от однотипных логов + формат улучшен 

было SetReadDeadline на каждый пакет syscall в ядро на каждую итерацию цикла чтения. 
теперь  обновляем  дедлайн только если прошло >15 сек с последнего вызова.
При тысячах пакетов в секунду это убирает ОГРОМНОЕ количество лишних syscalls. 


было dbMutex.Lock() на каждый пакет от каждого клиента. При 100+ соединениях массовый contention, горутины блокируются.

стало Локальные атомарные счётчики localUpBytes/localDownBytes (zero-contention).
Отдельная горутина с тикером 5 сек сбрасывает накопленное в db.Passwords под мьютексом.
Финальный flushStats() после proxyWg.Wait() при disconnect.

Убраны лишние логи на горячем пути, улучшена читаемость. 
Теперь меньше шанса забить диск логами

остальные изменения напишу но обьяснений не будет тк объяснять нечего 

ObfsState: sync.Mutex → atomic.AddUint64

SplitMix64 вместо crypto/rand для padding

sync.Pool для буферов в ReadFrom