### PR TITLE
Поддержка SRTP-WRAP-S / Free Turn Proxy

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="wdtt" />
+                <data android:scheme="vkturnproxy" />
+                <data android:scheme="freeturn" />
+            </intent-filter>
+            <intent-filter>
                 <action android:name="android.service.quicksettings.ACTION_QS_TILE_PREFERENCES" />
             </intent-filter>
         </activity>

--- a/app/src/main/assets/android-client/free_wrap.go
+++ b/app/src/main/assets/android-client/free_wrap.go
@@ -1,0 +1,346 @@
+package main
+
+import (
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+const (
+	freeProfileOpus  = "rtpopus"
+	freeProfileOpus2 = "rtpopus2"
+	freeProfileOpus3 = "rtpopus3"
+	freeRtpPayload   = 0x6f
+)
+
+type freeWrapCodec interface {
+	WrapInto(dst, payload []byte) (int, error)
+	UnwrapPacket(wire, dst []byte) (int, error)
+	Overhead() int
+}
+
+func newFreeWrapCodec(profile string, key []byte) (freeWrapCodec, error) {
+	switch profile {
+	case freeProfileOpus:
+		return newFreeWrap1(key)
+	case freeProfileOpus2:
+		return newFreeWrap2(key)
+	case freeProfileOpus3:
+		return newFreeWrap3(key)
+	default:
+		return nil, fmt.Errorf("free wrap: unknown obf profile %q", profile)
+	}
+}
+
+func writeFreeTurnClientID(conn net.Conn, clientID string) error {
+	b := []byte(clientID)
+	if len(b) > 255 {
+		b = b[:255]
+	}
+	record := make([]byte, len(b)+1)
+	record[0] = byte(len(b))
+	copy(record[1:], b)
+	_, err := conn.Write(record)
+	return err
+}
+
+// rtpopus: RTP header + explicit nonce + ChaCha20-Poly1305 tag.
+type freeWrap1 struct {
+	aead      cipher.AEAD
+	sessionID [4]byte
+	ssrc      [4]byte
+	counter   atomic.Uint64
+	seq       atomic.Uint32
+	timestamp atomic.Uint32
+}
+
+func newFreeWrap1(key []byte) (*freeWrap1, error) {
+	if len(key) != wrapKeyLen {
+		return nil, fmt.Errorf("free wrap: key must be %d bytes", wrapKeyLen)
+	}
+	aead, err := chacha20poly1305.New(key)
+	if err != nil {
+		return nil, err
+	}
+	w := &freeWrap1{aead: aead}
+	var random [24]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return nil, err
+	}
+	copy(w.sessionID[:], random[0:4])
+	copy(w.ssrc[:], random[4:8])
+	w.sessionID[0] &^= 0x80
+	w.ssrc[0] &^= 0x80
+	w.seq.Store(uint32(binary.BigEndian.Uint16(random[8:10])))
+	w.timestamp.Store(binary.BigEndian.Uint32(random[10:14]))
+	w.counter.Store(binary.BigEndian.Uint64(random[16:24]))
+	return w, nil
+}
+
+func (w *freeWrap1) Overhead() int { return 40 }
+
+func (w *freeWrap1) WrapInto(dst, payload []byte) (int, error) {
+	const headerLen = 24
+	wireLen := len(payload) + w.Overhead()
+	if len(dst) < wireLen {
+		return 0, errors.New("free wrap: dst too small")
+	}
+	dst[0], dst[1] = 0x80, freeRtpPayload
+	seq := uint16(w.seq.Add(1) - 1)
+	binary.BigEndian.PutUint16(dst[2:4], seq)
+	ts := w.timestamp.Add(960) - 960
+	binary.BigEndian.PutUint32(dst[4:8], ts)
+	copy(dst[8:12], w.ssrc[:])
+	copy(dst[12:16], w.sessionID[:])
+	binary.BigEndian.PutUint64(dst[16:24], w.counter.Add(1)-1)
+	copy(dst[headerLen:], payload)
+	w.aead.Seal(dst[headerLen:headerLen], dst[12:24], dst[headerLen:headerLen+len(payload)], dst[:headerLen])
+	return wireLen, nil
+}
+
+func (w *freeWrap1) UnwrapPacket(wire, dst []byte) (int, error) {
+	if len(wire) < w.Overhead() {
+		return 0, errors.New("free wrap: packet too short")
+	}
+	plain, err := w.aead.Open(nil, wire[12:24], wire[24:], wire[:24])
+	if err != nil {
+		return 0, err
+	}
+	if len(plain) > len(dst) {
+		return 0, errors.New("free wrap: dst too small")
+	}
+	copy(dst, plain)
+	return len(plain), nil
+}
+
+// rtpopus2: RTP one-byte extension + explicit nonce.
+type freeWrap2 struct {
+	aead      cipher.AEAD
+	sessionID [4]byte
+	ssrc      [4]byte
+	counter   atomic.Uint64
+	seq       atomic.Uint32
+	timestamp atomic.Uint32
+	tcc       atomic.Uint32
+	first     atomic.Bool
+}
+
+func newFreeWrap2(key []byte) (*freeWrap2, error) {
+	if len(key) != wrapKeyLen {
+		return nil, fmt.Errorf("free wrap2: key must be %d bytes", wrapKeyLen)
+	}
+	aead, err := chacha20poly1305.New(key)
+	if err != nil {
+		return nil, err
+	}
+	w := &freeWrap2{aead: aead}
+	var random [24]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return nil, err
+	}
+	copy(w.sessionID[:], random[0:4])
+	copy(w.ssrc[:], random[4:8])
+	w.sessionID[0] &^= 0x80
+	w.seq.Store(uint32(binary.BigEndian.Uint16(random[8:10])))
+	w.timestamp.Store(binary.BigEndian.Uint32(random[10:14]))
+	w.tcc.Store(uint32(binary.BigEndian.Uint16(random[14:16])))
+	w.counter.Store(binary.BigEndian.Uint64(random[16:24]))
+	return w, nil
+}
+
+func (w *freeWrap2) Overhead() int { return 52 }
+
+func (w *freeWrap2) WrapInto(dst, payload []byte) (int, error) {
+	const headerLen = 36
+	wireLen := len(payload) + w.Overhead()
+	if len(dst) < wireLen {
+		return 0, errors.New("free wrap2: dst too small")
+	}
+	dst[0] = 0x90
+	pt := byte(freeRtpPayload)
+	if w.first.CompareAndSwap(false, true) {
+		pt |= 0x80
+	}
+	dst[1] = pt
+	seq := uint16(w.seq.Add(1) - 1)
+	binary.BigEndian.PutUint16(dst[2:4], seq)
+	binary.BigEndian.PutUint32(dst[4:8], w.timestamp.Add(960)-960)
+	copy(dst[8:12], w.ssrc[:])
+	dst[12], dst[13] = 0xbe, 0xde
+	binary.BigEndian.PutUint16(dst[14:16], 2)
+	dst[16], dst[17] = 0x10, 0x80|byte(seq&0x3f)
+	dst[18] = 0x21
+	binary.BigEndian.PutUint16(dst[19:21], uint16(w.tcc.Add(1)-1))
+	dst[21], dst[22], dst[23] = 0, 0, 0
+	copy(dst[24:28], w.sessionID[:])
+	binary.BigEndian.PutUint64(dst[28:36], w.counter.Add(1)-1)
+	copy(dst[headerLen:], payload)
+	w.aead.Seal(dst[headerLen:headerLen], dst[24:36], dst[headerLen:headerLen+len(payload)], dst[:headerLen])
+	return wireLen, nil
+}
+
+func (w *freeWrap2) UnwrapPacket(wire, dst []byte) (int, error) {
+	if len(wire) < w.Overhead() {
+		return 0, errors.New("free wrap2: packet too short")
+	}
+	plain, err := w.aead.Open(nil, wire[24:36], wire[36:], wire[:36])
+	if err != nil {
+		return 0, err
+	}
+	if len(plain) > len(dst) {
+		return 0, errors.New("free wrap2: dst too small")
+	}
+	copy(dst, plain)
+	return len(plain), nil
+}
+
+// rtpopus3 extends rtpopus2 with abs-send-time and voice-like pacing fields.
+type freeWrap3 struct {
+	aead      cipher.AEAD
+	sessionID [4]byte
+	ssrc      [4]byte
+	start     time.Time
+	mu        sync.Mutex
+	counter   uint64
+	seq       uint16
+	timestamp uint32
+	tcc       uint16
+	speech    bool
+	stateLeft int
+	gapLeft   int
+	gapSize   int
+}
+
+func newFreeWrap3(key []byte) (*freeWrap3, error) {
+	if len(key) != wrapKeyLen {
+		return nil, fmt.Errorf("free wrap3: key must be %d bytes", wrapKeyLen)
+	}
+	aead, err := chacha20poly1305.New(key)
+	if err != nil {
+		return nil, err
+	}
+	var random [24]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return nil, err
+	}
+	w := &freeWrap3{aead: aead, start: time.Now(), speech: true}
+	copy(w.sessionID[:], random[0:4])
+	copy(w.ssrc[:], random[4:8])
+	w.sessionID[0] &^= 0x80
+	w.seq = binary.BigEndian.Uint16(random[8:10])
+	w.timestamp = binary.BigEndian.Uint32(random[10:14])
+	w.tcc = binary.BigEndian.Uint16(random[14:16])
+	w.counter = binary.BigEndian.Uint64(random[16:24])
+	w.stateLeft = 30 + freeRand(171)
+	w.gapLeft = 50 + freeRand(101)
+	w.gapSize = 1 + freeRand(3)
+	return w, nil
+}
+
+func (w *freeWrap3) Overhead() int { return 56 }
+
+func (w *freeWrap3) WrapInto(dst, payload []byte) (int, error) {
+	const headerLen = 40
+	wireLen := len(payload) + w.Overhead()
+	if len(dst) < wireLen {
+		return 0, errors.New("free wrap3: dst too small")
+	}
+	w.mu.Lock()
+	w.stateLeft--
+	marker := false
+	if w.stateLeft == 0 {
+		w.speech = !w.speech
+		if w.speech {
+			w.stateLeft = 30 + freeRand(171)
+			marker = true
+		} else {
+			w.stateLeft = 5 + freeRand(26)
+		}
+	}
+	seq := w.seq
+	w.seq++
+	w.gapLeft--
+	if w.gapLeft == 0 {
+		w.seq += uint16(w.gapSize)
+		w.gapLeft = 50 + freeRand(101)
+		w.gapSize = 1 + freeRand(3)
+	}
+	ts := w.timestamp
+	w.timestamp += freeTimestampStep()
+	tcc := w.tcc
+	w.tcc++
+	ctr := w.counter
+	w.counter++
+	level := byte(100 + freeRand(28))
+	if w.speech {
+		level = 0x80 | byte(20+freeRand(31))
+	}
+	w.mu.Unlock()
+
+	dst[0] = 0x90
+	dst[1] = freeRtpPayload
+	if marker { dst[1] |= 0x80 }
+	binary.BigEndian.PutUint16(dst[2:4], seq)
+	binary.BigEndian.PutUint32(dst[4:8], ts)
+	copy(dst[8:12], w.ssrc[:])
+	dst[12], dst[13] = 0xbe, 0xde
+	binary.BigEndian.PutUint16(dst[14:16], 3)
+	dst[16], dst[17] = 0x10, level
+	dst[18] = 0x21
+	binary.BigEndian.PutUint16(dst[19:21], tcc)
+	dst[21] = 0x32
+	abs := freeAbsSendTime(w.start)
+	dst[22], dst[23], dst[24] = byte(abs>>16), byte(abs>>8), byte(abs)
+	dst[25], dst[26], dst[27] = 0, 0, 0
+	copy(dst[28:32], w.sessionID[:])
+	binary.BigEndian.PutUint64(dst[32:40], ctr)
+	copy(dst[headerLen:], payload)
+	w.aead.Seal(dst[headerLen:headerLen], dst[28:40], dst[headerLen:headerLen+len(payload)], dst[:headerLen])
+	return wireLen, nil
+}
+
+func (w *freeWrap3) UnwrapPacket(wire, dst []byte) (int, error) {
+	if len(wire) < w.Overhead() {
+		return 0, errors.New("free wrap3: packet too short")
+	}
+	plain, err := w.aead.Open(nil, wire[28:40], wire[40:], wire[:40])
+	if err != nil {
+		return 0, err
+	}
+	if len(plain) > len(dst) {
+		return 0, errors.New("free wrap3: dst too small")
+	}
+	copy(dst, plain)
+	return len(plain), nil
+}
+
+func freeRand(limit int) int {
+	if limit <= 1 { return 0 }
+	var value [1]byte
+	if _, err := rand.Read(value[:]); err != nil { panic(err) }
+	return int(value[0]) % limit
+}
+
+func freeTimestampStep() uint32 {
+	switch r := freeRand(256); {
+	case r < 10:
+		return 480
+	case r < 230:
+		return 960
+	default:
+		return 1920
+	}
+}
+
+func freeAbsSendTime(start time.Time) uint32 {
+	ms := time.Since(start).Milliseconds()
+	return uint32((ms/1000)%64)<<18 | uint32((ms%1000)<<18/1000)
+}

--- a/app/src/main/assets/android-client/main.go
+++ b/app/src/main/assets/android-client/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"log"
@@ -155,6 +156,10 @@ func main() {
 	fingerprint := flag.String("fingerprint", "chrome", "браузерный фингерпринт (chrome, safari, ios, android, firefox)")
 	clientIdsFlag := flag.String("client-ids", "", "ID клиентов VK через запятую")
 	obfsMode := flag.String("obfs", "audio", "режим обфускации (audio/video)")
+	useWrapS := flag.Bool("wrap-s", false, "SRTP-WRAP-S для free-turn-proxy")
+	freeObfProfile := flag.String("obf-profile", freeProfileOpus3, "free-turn OBF profile")
+	freeObfKey := flag.String("obf-key", "", "free-turn OBF key (64 hex chars)")
+	freeClientID := flag.String("free-client-id", "", "free-turn Client ID")
 
 	flag.Parse()
 	activeVKAuthMode := setVKAuthMode(*vkAuthMode)
@@ -190,13 +195,26 @@ func main() {
 		log.Fatal("[КЛИЕНТ] Нет хешей VK")
 	}
 
-	if *connPassword == "" {
-		log.Fatal("[КЛИЕНТ] Нужен -password: WRAP ключ теперь выводится из пароля подключения")
-	}
-
-	wrapKey, err := deriveWrapKey(*connPassword)
-	if err != nil {
-		log.Fatalf("[КЛИЕНТ] WRAP key derive: %v", err)
+	var wrapKey []byte
+	if *useWrapS {
+		if *freeClientID == "" {
+			log.Fatal("[КЛИЕНТ] Для SRTP-WRAP-S нужен -free-client-id")
+		}
+		if *freeObfProfile != freeProfileOpus && *freeObfProfile != freeProfileOpus2 && *freeObfProfile != freeProfileOpus3 {
+			log.Fatalf("[КЛИЕНТ] Неизвестный OBF profile: %s", *freeObfProfile)
+		}
+		wrapKey, err = hex.DecodeString(strings.TrimSpace(*freeObfKey))
+		if err != nil || len(wrapKey) != wrapKeyLen {
+			log.Fatal("[КЛИЕНТ] Для SRTP-WRAP-S нужен -obf-key из 64 hex символов")
+		}
+	} else {
+		if *connPassword == "" {
+			log.Fatal("[КЛИЕНТ] Нужен -password: WRAP ключ теперь выводится из пароля подключения")
+		}
+		wrapKey, err = deriveWrapKey(*connPassword)
+		if err != nil {
+			log.Fatalf("[КЛИЕНТ] WRAP key derive: %v", err)
+		}
 	}
 
 	maxWorkers := 108
@@ -214,6 +232,9 @@ func main() {
 		Hashes:   hashes,
 		WrapKey:  wrapKey,
 		ObfsMode: *obfsMode,
+		UseWrapS: *useWrapS,
+		ObfProfile: *freeObfProfile,
+		ClientID: *freeClientID,
 	}
 
 	var localConn net.PacketConn
@@ -250,7 +271,9 @@ func main() {
 	numGroups := *numW / workersPerGroup
 
 	wrapStatus := "OFF"
-	if len(wrapKey) == wrapKeyLen {
+	if *useWrapS {
+		wrapStatus = fmt.Sprintf("SRTP-WRAP-S (%s, Client ID %s)", *freeObfProfile, *freeClientID)
+	} else if len(wrapKey) == wrapKeyLen {
 		wrapStatus = "ON (password HKDF + RTP AEAD)"
 	}
 
@@ -271,7 +294,11 @@ func main() {
 	log.Printf("[КЛИЕНТ] Слушаю: %s | Пир: %s", *listen, cleanPeerAddr)
 	log.Printf("[КЛИЕНТ] Протокол: UDP")
 	log.Printf("[КЛИЕНТ] WRAP: %s", wrapStatus)
-	log.Printf("[WRAP] Ключ выведен из пароля, режим RTP AEAD активен")
+	if *useWrapS {
+		log.Printf("[WRAP-S] Free Turn profile=%s, Client ID активен", *freeObfProfile)
+	} else {
+		log.Printf("[WRAP] Ключ выведен из пароля, режим RTP AEAD активен")
+	}
 	log.Printf("[КЛИЕНТ] Device ID: %s", *deviceID)
 	log.Printf("[КЛИЕНТ] Captcha: %s", captchaStatus)
 	log.Println("[КЛИЕНТ] ═══════════════════════════════════════")
@@ -368,7 +395,7 @@ func main() {
 		go func(groupID int, isFirstGroup bool, configChan chan<- string, workerIds []int, startHashIndex int, waitC, waitS <-chan struct{}, sigC, sigS chan<- struct{}) {
 			defer wg.Done()
 			WorkerGroup(ctx, groupID, startHashIndex, tp, peer, disp, localPort,
-				isFirstGroup, configChan, workerIds, &pauseFlag, *deviceID, *connPassword, stats, waitC, sigC, waitS, sigS)
+				isFirstGroup && !*useWrapS, configChan, workerIds, &pauseFlag, *deviceID, *connPassword, stats, waitC, sigC, waitS, sigS)
 		}(gID, isFirst, cc, ids, g, myWaitCreds, myWaitSpawn, mySignalCreds, mySignalSpawn)
 	}
 

--- a/app/src/main/assets/android-client/session.go
+++ b/app/src/main/assets/android-client/session.go
@@ -144,7 +144,14 @@ func RunSession(
 	var relayWg sync.WaitGroup
 	relayWg.Add(2)
 
-	useWrap := len(tp.WrapKey) == wrapKeyLen
+	useWrap := len(tp.WrapKey) == wrapKeyLen && !tp.UseWrapS
+	var freeWrap freeWrapCodec
+	if tp.UseWrapS {
+		freeWrap, err = newFreeWrapCodec(tp.ObfProfile, tp.WrapKey)
+		if err != nil {
+			return false, fmt.Errorf("SRTP-WRAP-S init: %w", err)
+		}
+	}
 
 	var obfsCfg *ObfsConfig
 	var obfsWriteState *ObfsState
@@ -164,6 +171,9 @@ func RunSession(
 		defer sessCancel()
 
 		readBufLen := readBufSize + 80
+		if freeWrap != nil {
+			readBufLen = readBufSize + freeWrap.Overhead()
+		}
 		buf := make([]byte, readBufLen)
 		plain := make([]byte, readBufSize)
 		for {
@@ -183,6 +193,13 @@ func RunSession(
 					continue
 				}
 				payload = plain[:m]
+			} else if freeWrap != nil {
+				m, wrapErr := freeWrap.UnwrapPacket(payload, plain)
+				if wrapErr != nil {
+					log.Printf("[СЕССИЯ #%d] WRAP-S unwrap: %v (n=%d)", sessionID, wrapErr, n)
+					continue
+				}
+				payload = plain[:m]
 			}
 			if _, writeErr := pipeA.WriteTo(payload, peer); writeErr != nil {
 				return
@@ -194,6 +211,10 @@ func RunSession(
 		defer relayWg.Done()
 		defer sessCancel()
 		b := make([]byte, readBufSize)
+		var freeWire []byte
+		if freeWrap != nil {
+			freeWire = make([]byte, readBufSize+freeWrap.Overhead())
+		}
 		for {
 			n, _, readErr := pipeA.ReadFrom(b)
 			if readErr != nil {
@@ -209,6 +230,13 @@ func RunSession(
 					}
 					out = wrapped
 				}
+			} else if freeWrap != nil {
+				n, wrapErr := freeWrap.WrapInto(freeWire, out)
+				if wrapErr != nil {
+					log.Printf("[СЕССИЯ #%d] WRAP-S wrap: %v", sessionID, wrapErr)
+					return
+				}
+				out = freeWire[:n]
 			}
 			if _, writeErr := relay.WriteTo(out, peer); writeErr != nil {
 				return
@@ -249,7 +277,7 @@ func RunSession(
 	<-handshakeSem
 
 	if err != nil {
-		if useWrap {
+		if useWrap || freeWrap != nil {
 			errStr := strings.ToLower(err.Error())
 			if strings.Contains(errStr, "deadline") || strings.Contains(errStr, "timeout") {
 				return false, fmt.Errorf("WRAP_AUTH_TIMEOUT: DTLS timeout, пароль/WRAP не подтверждён")
@@ -258,6 +286,11 @@ func RunSession(
 		return false, fmt.Errorf("DTLS хендшейк: %w", err)
 	}
 	log.Printf("[ВОРКЕР #%d] [DTLS] Соединение установлено ✓", sessionID)
+	if freeWrap != nil {
+		if err := writeFreeTurnClientID(dtlsConn, tp.ClientID); err != nil {
+			return false, fmt.Errorf("SRTP-WRAP-S Client ID: %w", err)
+		}
+	}
 
 	stats.ActiveConnections.Add(1)
 	defer stats.ActiveConnections.Add(-1)

--- a/app/src/main/assets/android-client/worker_group.go
+++ b/app/src/main/assets/android-client/worker_group.go
@@ -279,6 +279,9 @@ type TurnParams struct {
 	Hashes   []string
 	WrapKey  []byte
 	ObfsMode string
+	UseWrapS bool
+	ObfProfile string
+	ClientID string
 }
 
 type Credentials struct {

--- a/app/src/main/java/com/wdtt/client/ConnectionProfile.kt
+++ b/app/src/main/java/com/wdtt/client/ConnectionProfile.kt
@@ -1,0 +1,245 @@
+package com.wdtt.client
+
+import android.net.Uri
+import android.util.Base64
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.UUID
+
+enum class ConnectionMode(val label: String) {
+    WRAP_A("SRTP-WRAP-A"),
+    WRAP_S("SRTP-WRAP-S")
+}
+
+data class ConnectionProfile(
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val mode: ConnectionMode,
+    val peer: String,
+    val vkLinks: String,
+    val localPort: Int = 9000,
+    val workers: Int = 18,
+    val wrapAPassword: String = "",
+    val obfKey: String = "",
+    val obfProfile: String = "rtpopus3",
+    val clientId: String = "",
+    val wireGuardConfig: String = "",
+    val sourceLink: String = ""
+) {
+    val isReady: Boolean
+        get() = peer.isNotBlank() && vkLinks.isNotBlank() && when (mode) {
+            ConnectionMode.WRAP_A -> wrapAPassword.isNotBlank()
+            ConnectionMode.WRAP_S -> obfKey.length == 64 && clientId.isNotBlank() && wireGuardConfig.isNotBlank()
+        }
+
+    fun toJson(): JSONObject = JSONObject().apply {
+        put("id", id)
+        put("name", name)
+        put("mode", mode.name)
+        put("peer", peer)
+        put("vkLinks", vkLinks)
+        put("localPort", localPort)
+        put("workers", workers)
+        put("wrapAPassword", wrapAPassword)
+        put("obfKey", obfKey)
+        put("obfProfile", obfProfile)
+        put("clientId", clientId)
+        put("wireGuardConfig", wireGuardConfig)
+        put("sourceLink", sourceLink)
+    }
+
+    companion object {
+        fun fromJson(json: JSONObject): ConnectionProfile? = runCatching {
+            val mode = ConnectionMode.valueOf(json.optString("mode"))
+            ConnectionProfile(
+                id = json.optString("id").ifBlank { UUID.randomUUID().toString() },
+                name = json.optString("name").ifBlank { json.optString("peer") },
+                mode = mode,
+                peer = json.optString("peer"),
+                vkLinks = json.optString("vkLinks"),
+                localPort = json.optInt("localPort", 9000).coerceIn(1, 65535),
+                workers = json.optInt("workers", 18).coerceIn(9, 108),
+                wrapAPassword = json.optString("wrapAPassword"),
+                obfKey = json.optString("obfKey"),
+                obfProfile = json.optString("obfProfile", "rtpopus3"),
+                clientId = json.optString("clientId"),
+                wireGuardConfig = json.optString("wireGuardConfig"),
+                sourceLink = json.optString("sourceLink")
+            )
+        }.getOrNull()
+
+        fun encodeList(profiles: List<ConnectionProfile>): String = JSONArray().apply {
+            profiles.forEach { put(it.toJson()) }
+        }.toString()
+
+        fun decodeList(value: String): List<ConnectionProfile> = runCatching {
+            val array = JSONArray(value)
+            buildList {
+                for (index in 0 until array.length()) {
+                    fromJson(array.optJSONObject(index) ?: continue)?.let(::add)
+                }
+            }
+        }.getOrDefault(emptyList())
+    }
+}
+
+object ConnectionProfileParser {
+    fun parse(rawLink: String): ConnectionProfile {
+        val raw = rawLink.trim()
+        require(raw.isNotEmpty()) { "Ссылка пуста" }
+        return when (Uri.parse(raw).scheme?.lowercase()) {
+            "wdtt" -> parseWdtt(raw)
+            "vkturnproxy" -> parseVkTurnProxy(raw)
+            "freeturn" -> parseFreeTurn(raw)
+            else -> throw IllegalArgumentException("Поддерживаются ссылки wdtt://, vkturnproxy:// и freeturn://")
+        }
+    }
+
+    private fun parseWdtt(raw: String): ConnectionProfile {
+        val parts = raw.removePrefix("wdtt://").split(":")
+        require(parts.size >= 6) { "Некорректная ссылка wdtt://" }
+        val host = parts[0].trim()
+        val dtlsPort = parts[1].toIntOrNull()?.takeIf { it in 1..65535 }
+            ?: throw IllegalArgumentException("Некорректный DTLS-порт в wdtt://")
+        val localPort = parts[3].toIntOrNull()?.takeIf { it in 1..65535 } ?: 9000
+        val password = parts[4].trim()
+        val vkLinks = parts.drop(5).joinToString(":").trim()
+        require(host.isNotBlank() && password.isNotBlank() && vkLinks.isNotBlank()) {
+            "Ссылка wdtt:// не содержит обязательные параметры"
+        }
+        return ConnectionProfile(
+            name = "$host:$dtlsPort",
+            mode = ConnectionMode.WRAP_A,
+            peer = "$host:$dtlsPort",
+            vkLinks = vkLinks,
+            localPort = localPort,
+            wrapAPassword = password,
+            sourceLink = raw
+        )
+    }
+
+    private fun parseVkTurnProxy(raw: String): ConnectionProfile {
+        val uri = Uri.parse(raw)
+        require(uri.host.isNullOrBlank() || uri.host.equals("import", true)) { "Неверный vkturnproxy:// URL" }
+        val data = uri.getQueryParameter("data")?.takeIf { it.isNotBlank() }
+            ?: throw IllegalArgumentException("В vkturnproxy:// отсутствует data")
+        val root = JSONObject(decodeBase64Url(data).toString(Charsets.UTF_8))
+        val settings = root.optJSONObject("settings") ?: throw IllegalArgumentException("В vkturnproxy:// отсутствуют настройки")
+        val useWrapS = settings.optBoolean("useWrapS", false)
+        val useWrapA = settings.optBoolean("useWrapA", false)
+        val peer = settings.stringValue("peerAddress")
+        require(peer.isNotBlank()) { "В ссылке не указан адрес сервера" }
+        return when {
+            useWrapS -> freeTurnProfile(
+                peer = peer,
+                vkLinks = settings.stringValue("vkLink"),
+                workers = settings.optInt("numConnections", 18),
+                obfKey = settings.stringValue("wrapKeyHex"),
+                obfProfile = settings.stringValue("obfProfile").ifBlank { "rtpopus3" },
+                clientId = settings.stringValue("clientID"),
+                privateKey = settings.stringValue("privateKey"),
+                peerPublicKey = settings.stringValue("peerPublicKey"),
+                tunnelAddress = settings.stringValue("tunnelAddress"),
+                dnsServers = settings.stringValue("dnsServers"),
+                raw = raw
+            )
+            useWrapA -> ConnectionProfile(
+                name = peer,
+                mode = ConnectionMode.WRAP_A,
+                peer = peer,
+                vkLinks = settings.stringValue("vkLink"),
+                localPort = 9000,
+                workers = settings.optInt("numConnections", 18).coerceIn(9, 108),
+                wrapAPassword = settings.stringValue("wrapAPassword"),
+                sourceLink = raw
+            )
+            else -> throw IllegalArgumentException("vkturnproxy:// не содержит SRTP-WRAP-A или SRTP-WRAP-S")
+        }
+    }
+
+    private fun parseFreeTurn(raw: String): ConnectionProfile {
+        val encoded = raw.removePrefix("freeturn://").trimEnd('/')
+        require(encoded.isNotBlank()) { "В freeturn:// отсутствуют данные" }
+        val json = JSONObject(decodeBase64Url(encoded).toString(Charsets.UTF_8))
+        val version = json.optInt("v", 1)
+        require(version == 1) { "Неподдерживаемая версия freeturn://: $version" }
+        val peer = json.stringValue("peer")
+        require(peer.isNotBlank()) { "В freeturn:// не указан адрес сервера" }
+        return freeTurnProfile(
+            peer = peer,
+            vkLinks = "",
+            workers = json.optInt("n", 18),
+            obfKey = json.stringValue("key"),
+            obfProfile = json.stringValue("obf").ifBlank { "rtpopus3" },
+            clientId = json.stringValue("cid"),
+            privateKey = "",
+            peerPublicKey = "",
+            tunnelAddress = "",
+            dnsServers = json.stringValue("dnss"),
+            raw = raw
+        )
+    }
+
+    private fun freeTurnProfile(
+        peer: String,
+        vkLinks: String,
+        workers: Int,
+        obfKey: String,
+        obfProfile: String,
+        clientId: String,
+        privateKey: String,
+        peerPublicKey: String,
+        tunnelAddress: String,
+        dnsServers: String,
+        raw: String
+    ): ConnectionProfile {
+        require(obfProfile in setOf("rtpopus", "rtpopus2", "rtpopus3")) {
+            "Неизвестный OBF profile: $obfProfile"
+        }
+        val wireGuardConfig = if (privateKey.isNotBlank() && peerPublicKey.isNotBlank() && tunnelAddress.isNotBlank()) {
+            buildWireGuardConfig(privateKey, peerPublicKey, tunnelAddress, dnsServers)
+        } else {
+            ""
+        }
+        return ConnectionProfile(
+            name = peer,
+            mode = ConnectionMode.WRAP_S,
+            peer = peer,
+            vkLinks = vkLinks,
+            localPort = 9000,
+            workers = workers.coerceIn(9, 108),
+            obfKey = obfKey.lowercase(),
+            obfProfile = obfProfile,
+            clientId = clientId.ifBlank { UUID.randomUUID().toString() },
+            wireGuardConfig = wireGuardConfig,
+            sourceLink = raw
+        )
+    }
+
+    private fun buildWireGuardConfig(
+        privateKey: String,
+        peerPublicKey: String,
+        tunnelAddress: String,
+        dnsServers: String
+    ): String = buildString {
+        appendLine("[Interface]")
+        appendLine("PrivateKey = $privateKey")
+        appendLine("Address = $tunnelAddress")
+        if (dnsServers.isNotBlank()) appendLine("DNS = $dnsServers")
+        appendLine("MTU = 1280")
+        appendLine()
+        appendLine("[Peer]")
+        appendLine("PublicKey = $peerPublicKey")
+        appendLine("AllowedIPs = 0.0.0.0/0, ::/0")
+        appendLine("Endpoint = 127.0.0.1:9000")
+        append("PersistentKeepalive = 25")
+    }
+
+    private fun decodeBase64Url(value: String): ByteArray {
+        val normalized = value.replace('-', '+').replace('_', '/')
+        val padded = normalized + "=".repeat((4 - normalized.length % 4) % 4)
+        return Base64.decode(padded, Base64.DEFAULT)
+    }
+
+    private fun JSONObject.stringValue(name: String): String = optString(name, "").trim()
+}

--- a/app/src/main/java/com/wdtt/client/ConnectionProfile.kt
+++ b/app/src/main/java/com/wdtt/client/ConnectionProfile.kt
@@ -93,8 +93,10 @@ object ConnectionProfileParser {
         return when (Uri.parse(raw).scheme?.lowercase()) {
             "wdtt" -> parseWdtt(raw)
             "vkturnproxy" -> parseVkTurnProxy(raw)
-            "freeturn" -> parseFreeTurn(raw)
-            else -> throw IllegalArgumentException("Поддерживаются ссылки wdtt://, vkturnproxy:// и freeturn://")
+            "freeturn" -> throw IllegalArgumentException(
+                "freeturn:// не содержит VK-ссылку и WireGuard-конфиг; используйте vkturnproxy://"
+            )
+            else -> throw IllegalArgumentException("Поддерживаются ссылки wdtt:// и vkturnproxy://")
         }
     }
 
@@ -158,29 +160,6 @@ object ConnectionProfileParser {
             )
             else -> throw IllegalArgumentException("vkturnproxy:// не содержит SRTP-WRAP-A или SRTP-WRAP-S")
         }
-    }
-
-    private fun parseFreeTurn(raw: String): ConnectionProfile {
-        val encoded = raw.removePrefix("freeturn://").trimEnd('/')
-        require(encoded.isNotBlank()) { "В freeturn:// отсутствуют данные" }
-        val json = JSONObject(decodeBase64Url(encoded).toString(Charsets.UTF_8))
-        val version = json.optInt("v", 1)
-        require(version == 1) { "Неподдерживаемая версия freeturn://: $version" }
-        val peer = json.stringValue("peer")
-        require(peer.isNotBlank()) { "В freeturn:// не указан адрес сервера" }
-        return freeTurnProfile(
-            peer = peer,
-            vkLinks = "",
-            workers = json.optInt("n", 18),
-            obfKey = json.stringValue("key"),
-            obfProfile = json.stringValue("obf").ifBlank { "rtpopus3" },
-            clientId = json.stringValue("cid"),
-            privateKey = "",
-            peerPublicKey = "",
-            tunnelAddress = "",
-            dnsServers = json.stringValue("dnss"),
-            raw = raw
-        )
     }
 
     private fun freeTurnProfile(

--- a/app/src/main/java/com/wdtt/client/ConnectionProfile.kt
+++ b/app/src/main/java/com/wdtt/client/ConnectionProfile.kt
@@ -11,6 +11,9 @@ enum class ConnectionMode(val label: String) {
     WRAP_S("SRTP-WRAP-S")
 }
 
+fun normalizeConnectionProfileWorkers(value: Int): Int =
+    (value.coerceIn(9, 27) / 9) * 9
+
 data class ConnectionProfile(
     val id: String = UUID.randomUUID().toString(),
     val name: String,
@@ -58,7 +61,7 @@ data class ConnectionProfile(
                 peer = json.optString("peer"),
                 vkLinks = json.optString("vkLinks"),
                 localPort = json.optInt("localPort", 9000).coerceIn(1, 65535),
-                workers = json.optInt("workers", 18).coerceIn(9, 108),
+                workers = normalizeConnectionProfileWorkers(json.optInt("workers", 18)),
                 wrapAPassword = json.optString("wrapAPassword"),
                 obfKey = json.optString("obfKey"),
                 obfProfile = json.optString("obfProfile", "rtpopus3"),
@@ -149,7 +152,7 @@ object ConnectionProfileParser {
                 peer = peer,
                 vkLinks = settings.stringValue("vkLink"),
                 localPort = 9000,
-                workers = settings.optInt("numConnections", 18).coerceIn(9, 108),
+                workers = normalizeConnectionProfileWorkers(settings.optInt("numConnections", 18)),
                 wrapAPassword = settings.stringValue("wrapAPassword"),
                 sourceLink = raw
             )
@@ -207,7 +210,7 @@ object ConnectionProfileParser {
             peer = peer,
             vkLinks = vkLinks,
             localPort = 9000,
-            workers = workers.coerceIn(9, 108),
+            workers = normalizeConnectionProfileWorkers(workers),
             obfKey = obfKey.lowercase(),
             obfProfile = obfProfile,
             clientId = clientId.ifBlank { UUID.randomUUID().toString() },

--- a/app/src/main/java/com/wdtt/client/MainActivity.kt
+++ b/app/src/main/java/com/wdtt/client/MainActivity.kt
@@ -112,6 +112,12 @@ class MainActivity : ComponentActivity() {
         activeActivities--
     }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        importConnectionLink(intent.dataString)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         
@@ -120,6 +126,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
 
         checkAndRequestNotifications()
+        importConnectionLink(intent.dataString)
 
         setContent {
             val settingsStore = remember { SettingsStore(this) }
@@ -156,6 +163,21 @@ class MainActivity : ComponentActivity() {
                         scope.launch { settingsStore.saveActiveClientIds(ids) }
                     }
                 )
+            }
+        }
+    }
+
+    private fun importConnectionLink(rawLink: String?) {
+        val raw = rawLink?.trim().orEmpty()
+        if (raw.isEmpty()) return
+        val profile = runCatching { ConnectionProfileParser.parse(raw) }.getOrElse { error ->
+            Toast.makeText(this, error.message ?: "Не удалось импортировать ссылку", Toast.LENGTH_LONG).show()
+            return
+        }
+        TunnelManager.scope.launch {
+            SettingsStore(applicationContext).saveConnectionProfile(profile)
+            runOnUiThread {
+                Toast.makeText(this@MainActivity, "Конфиг ${profile.mode.label} импортирован", Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/java/com/wdtt/client/QuickToggleTileService.kt
+++ b/app/src/main/java/com/wdtt/client/QuickToggleTileService.kt
@@ -113,7 +113,7 @@ class QuickToggleTileService : TileService() {
                 putExtra("workers_per_hash", profile?.workers ?: store.workersPerHash.first())
                 putExtra("port", localPort)
                 putExtra("sni", store.sni.first())
-                putExtra("connection_password", store.connectionPassword.first())
+                putExtra("connection_password", password)
                 putExtra("protocol", store.protocol.first())
                 putExtra("vk_auth_mode", store.vkAuthMode.first())
                 putExtra("captcha_mode", store.captchaMode.first())

--- a/app/src/main/java/com/wdtt/client/QuickToggleTileService.kt
+++ b/app/src/main/java/com/wdtt/client/QuickToggleTileService.kt
@@ -93,14 +93,16 @@ class QuickToggleTileService : TileService() {
     private suspend fun buildStartIntent(): Intent? {
         return runCatching {
             val store = SettingsStore(applicationContext)
-            val basePeer = store.peer.first()
-            val hashes = store.vkHashes.first()
-            val password = store.connectionPassword.first()
-            if (basePeer.isBlank() || hashes.isBlank() || password.isBlank()) return null
+            val profile = store.activeConnectionProfile()
+            val basePeer = profile?.peer ?: store.peer.first()
+            val hashes = profile?.vkLinks ?: store.vkHashes.first()
+            val password = profile?.wrapAPassword ?: store.connectionPassword.first()
+            val isFreeTurn = profile?.mode == ConnectionMode.WRAP_S
+            if (basePeer.isBlank() || hashes.isBlank() || (!isFreeTurn && password.isBlank()) || (isFreeTurn && profile?.isReady != true)) return null
 
             val manualPortsEnabled = store.manualPortsEnabled.first()
             val serverDtlsPort = if (manualPortsEnabled) store.serverDtlsPort.first() else 56000
-            val localPort = if (manualPortsEnabled) store.listenPort.first() else 9000
+            val localPort = profile?.localPort ?: if (manualPortsEnabled) store.listenPort.first() else 9000
             val peerWithPort = if (basePeer.contains(":")) basePeer else "$basePeer:$serverDtlsPort"
 
             Intent(this, TunnelService::class.java).apply {
@@ -108,7 +110,7 @@ class QuickToggleTileService : TileService() {
                 putExtra("peer", peerWithPort)
                 putExtra("vk_hashes", hashes)
                 putExtra("secondary_vk_hash", store.secondaryVkHash.first())
-                putExtra("workers_per_hash", store.workersPerHash.first())
+                putExtra("workers_per_hash", profile?.workers ?: store.workersPerHash.first())
                 putExtra("port", localPort)
                 putExtra("sni", store.sni.first())
                 putExtra("connection_password", store.connectionPassword.first())
@@ -119,6 +121,11 @@ class QuickToggleTileService : TileService() {
                 putExtra("fingerprint", store.selectedFingerprint.first())
                 putExtra("client_ids", store.activeClientIds.first())
                 putExtra("obfs_mode", store.obfsMode.first())
+                putExtra("free_turn", isFreeTurn)
+                putExtra("free_obf_key", profile?.obfKey.orEmpty())
+                putExtra("free_obf_profile", profile?.obfProfile.orEmpty())
+                putExtra("free_client_id", profile?.clientId.orEmpty())
+                putExtra("wireguard_config", profile?.wireGuardConfig.orEmpty())
             }
         }.getOrNull()
     }

--- a/app/src/main/java/com/wdtt/client/SettingsStore.kt
+++ b/app/src/main/java/com/wdtt/client/SettingsStore.kt
@@ -28,6 +28,8 @@ class SettingsStore(context: Context) {
         private val LOGGING_ENABLED = booleanPreferencesKey("logging_enabled")
         private val WDTT_LINK = stringPreferencesKey("wdtt_link")
         private val WDTT_LINK_MODE = booleanPreferencesKey("wdtt_link_mode")
+        private val CONNECTION_PROFILES_ENCRYPTED = stringPreferencesKey("connection_profiles_encrypted")
+        private val ACTIVE_CONNECTION_PROFILE_ID = stringPreferencesKey("active_connection_profile_id")
 
         private val PEER = stringPreferencesKey("peer")
         private val VK_HASHES = stringPreferencesKey("vk_hashes")
@@ -109,7 +111,7 @@ class SettingsStore(context: Context) {
             val newName = "${baseKey.name}_$profile"
             @Suppress("UNCHECKED_CAST")
             return when (baseKey) {
-                PEER, VK_HASHES, SECONDARY_VK_HASH, PROTOCOL, SNI, USER_AGENT, DEPLOY_IP, DEPLOY_LOGIN, DEPLOY_PASSWORD, DEPLOY_PASSWORD_ENCRYPTED, DEPLOY_SSH_PORT, DEPLOY_DNS1, DEPLOY_DNS2, EXCLUDED_APPS, CONNECTION_PASSWORD, CONNECTION_PASSWORD_ENCRYPTED, DEPLOY_MAIN_PASSWORD, DEPLOY_MAIN_PASSWORD_ENCRYPTED, DEPLOY_ADMIN_ID, DEPLOY_ADMIN_ID_ENCRYPTED, DEPLOY_BOT_TOKEN, DEPLOY_BOT_TOKEN_ENCRYPTED, PROXY_MODE, PROXY_HOST, VK_AUTH_MODE, OBFS_MODE, CAPTCHA_MODE, CAPTCHA_SOLVE_METHOD, CAPTCHA_WBV_SOLVE_METHOD, WDTT_LINK, SELECTED_FINGERPRINT, ACTIVE_CLIENT_IDS -> stringPreferencesKey(newName) as Preferences.Key<T>
+                PEER, VK_HASHES, SECONDARY_VK_HASH, PROTOCOL, SNI, USER_AGENT, DEPLOY_IP, DEPLOY_LOGIN, DEPLOY_PASSWORD, DEPLOY_PASSWORD_ENCRYPTED, DEPLOY_SSH_PORT, DEPLOY_DNS1, DEPLOY_DNS2, EXCLUDED_APPS, CONNECTION_PASSWORD, CONNECTION_PASSWORD_ENCRYPTED, DEPLOY_MAIN_PASSWORD, DEPLOY_MAIN_PASSWORD_ENCRYPTED, DEPLOY_ADMIN_ID, DEPLOY_ADMIN_ID_ENCRYPTED, DEPLOY_BOT_TOKEN, DEPLOY_BOT_TOKEN_ENCRYPTED, PROXY_MODE, PROXY_HOST, VK_AUTH_MODE, OBFS_MODE, CAPTCHA_MODE, CAPTCHA_SOLVE_METHOD, CAPTCHA_WBV_SOLVE_METHOD, WDTT_LINK, CONNECTION_PROFILES_ENCRYPTED, ACTIVE_CONNECTION_PROFILE_ID, SELECTED_FINGERPRINT, ACTIVE_CLIENT_IDS -> stringPreferencesKey(newName) as Preferences.Key<T>
                 WORKERS_PER_HASH, LISTEN_PORT, SERVER_DTLS_PORT, SERVER_WG_PORT, PROXY_PORT -> intPreferencesKey(newName) as Preferences.Key<T>
                 MANUAL_PORTS_ENABLED, NO_DTLS, NO_DNS, IS_WHITELIST, WDTT_LINK_MODE, DETAILED_LOGS -> booleanPreferencesKey(newName) as Preferences.Key<T>
                 else -> throw IllegalArgumentException("Unsupported key type: ${baseKey.name}")
@@ -124,6 +126,7 @@ class SettingsStore(context: Context) {
         CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
             migrateSecretsToKeystore()
             migrateLegacyWhitelistMode()
+            migrateLegacyWdttLink()
         }
     }
 
@@ -137,6 +140,15 @@ class SettingsStore(context: Context) {
     val wdttLinkMode: Flow<Boolean> = dataStore.data.map { prefs ->
         val profile = prefs[ACTIVE_PROFILE] ?: 0
         prefs[getProfileKey(WDTT_LINK_MODE, profile)] ?: false
+    }
+    val connectionProfiles: Flow<List<ConnectionProfile>> = dataStore.data.map { prefs ->
+        val profile = prefs[ACTIVE_PROFILE] ?: 0
+        val encrypted = prefs[getProfileKey(CONNECTION_PROFILES_ENCRYPTED, profile)]
+        ConnectionProfile.decodeList(secureStore.decrypt(encrypted).orEmpty())
+    }
+    val activeConnectionProfileId: Flow<String> = dataStore.data.map { prefs ->
+        val profile = prefs[ACTIVE_PROFILE] ?: 0
+        prefs[getProfileKey(ACTIVE_CONNECTION_PROFILE_ID, profile)] ?: ""
     }
 
     val peer: Flow<String> = dataStore.data.map { prefs ->
@@ -420,6 +432,55 @@ class SettingsStore(context: Context) {
         }
     }
 
+    suspend fun saveConnectionProfile(profile: ConnectionProfile) {
+        dataStore.edit { prefs ->
+            val activeSettingsProfile = prefs[ACTIVE_PROFILE] ?: 0
+            val profilesKey = getProfileKey(CONNECTION_PROFILES_ENCRYPTED, activeSettingsProfile)
+            val current = ConnectionProfile.decodeList(secureStore.decrypt(prefs[profilesKey]).orEmpty())
+            val updated = current.filterNot { it.id == profile.id || it.sourceLink == profile.sourceLink } + profile
+            prefs[profilesKey] = secureStore.encrypt(ConnectionProfile.encodeList(updated))
+            prefs[getProfileKey(ACTIVE_CONNECTION_PROFILE_ID, activeSettingsProfile)] = profile.id
+            prefs[getProfileKey(WDTT_LINK_MODE, activeSettingsProfile)] = true
+        }
+    }
+
+    suspend fun selectConnectionProfile(id: String) {
+        dataStore.edit { prefs ->
+            val profile = prefs[ACTIVE_PROFILE] ?: 0
+            prefs[getProfileKey(ACTIVE_CONNECTION_PROFILE_ID, profile)] = id
+            prefs[getProfileKey(WDTT_LINK_MODE, profile)] = true
+        }
+    }
+
+    suspend fun removeConnectionProfile(id: String) {
+        dataStore.edit { prefs ->
+            val activeSettingsProfile = prefs[ACTIVE_PROFILE] ?: 0
+            val profilesKey = getProfileKey(CONNECTION_PROFILES_ENCRYPTED, activeSettingsProfile)
+            val updated = ConnectionProfile.decodeList(secureStore.decrypt(prefs[profilesKey]).orEmpty())
+                .filterNot { it.id == id }
+            if (updated.isEmpty()) {
+                prefs.remove(profilesKey)
+                prefs.remove(getProfileKey(ACTIVE_CONNECTION_PROFILE_ID, activeSettingsProfile))
+            } else {
+                prefs[profilesKey] = secureStore.encrypt(ConnectionProfile.encodeList(updated))
+                val selected = prefs[getProfileKey(ACTIVE_CONNECTION_PROFILE_ID, activeSettingsProfile)]
+                if (selected == id) {
+                    prefs[getProfileKey(ACTIVE_CONNECTION_PROFILE_ID, activeSettingsProfile)] = updated.first().id
+                }
+            }
+        }
+    }
+
+    suspend fun activeConnectionProfile(): ConnectionProfile? {
+        val prefs = dataStore.data.first()
+        val profile = prefs[ACTIVE_PROFILE] ?: 0
+        val profiles = ConnectionProfile.decodeList(
+            secureStore.decrypt(prefs[getProfileKey(CONNECTION_PROFILES_ENCRYPTED, profile)]).orEmpty()
+        )
+        val selectedId = prefs[getProfileKey(ACTIVE_CONNECTION_PROFILE_ID, profile)]
+        return profiles.firstOrNull { it.id == selectedId } ?: profiles.firstOrNull()
+    }
+
     suspend fun save(
         peer: String,
         vkHashes: String,
@@ -577,6 +638,18 @@ class SettingsStore(context: Context) {
             prefs[getProfileKey(EXCLUDED_APPS, profile)] = packages
             prefs[getProfileKey(IS_WHITELIST, profile)] = isWhitelist
             prefs[SPLIT_TUNNEL_WHITELIST_MIGRATED] = true
+        }
+    }
+
+    private suspend fun migrateLegacyWdttLink() {
+        dataStore.edit { prefs ->
+            val profile = prefs[ACTIVE_PROFILE] ?: 0
+            val profilesKey = getProfileKey(CONNECTION_PROFILES_ENCRYPTED, profile)
+            if (!prefs[profilesKey].isNullOrBlank()) return@edit
+            val legacyLink = prefs[getProfileKey(WDTT_LINK, profile)] ?: return@edit
+            val imported = runCatching { ConnectionProfileParser.parse(legacyLink) }.getOrNull() ?: return@edit
+            prefs[profilesKey] = secureStore.encrypt(ConnectionProfile.encodeList(listOf(imported)))
+            prefs[getProfileKey(ACTIVE_CONNECTION_PROFILE_ID, profile)] = imported.id
         }
     }
 

--- a/app/src/main/java/com/wdtt/client/SettingsStore.kt
+++ b/app/src/main/java/com/wdtt/client/SettingsStore.kt
@@ -444,6 +444,18 @@ class SettingsStore(context: Context) {
         }
     }
 
+    suspend fun updateConnectionProfileWorkers(id: String, workers: Int) {
+        dataStore.edit { prefs ->
+            val activeSettingsProfile = prefs[ACTIVE_PROFILE] ?: 0
+            val profilesKey = getProfileKey(CONNECTION_PROFILES_ENCRYPTED, activeSettingsProfile)
+            val current = ConnectionProfile.decodeList(secureStore.decrypt(prefs[profilesKey]).orEmpty())
+            val updated = current.map { profile ->
+                if (profile.id == id) profile.copy(workers = normalizeConnectionProfileWorkers(workers)) else profile
+            }
+            prefs[profilesKey] = secureStore.encrypt(ConnectionProfile.encodeList(updated))
+        }
+    }
+
     suspend fun selectConnectionProfile(id: String) {
         dataStore.edit { prefs ->
             val profile = prefs[ACTIVE_PROFILE] ?: 0

--- a/app/src/main/java/com/wdtt/client/SettingsStore.kt
+++ b/app/src/main/java/com/wdtt/client/SettingsStore.kt
@@ -486,6 +486,7 @@ class SettingsStore(context: Context) {
     suspend fun activeConnectionProfile(): ConnectionProfile? {
         val prefs = dataStore.data.first()
         val profile = prefs[ACTIVE_PROFILE] ?: 0
+        if (prefs[getProfileKey(WDTT_LINK_MODE, profile)] != true) return null
         val profiles = ConnectionProfile.decodeList(
             secureStore.decrypt(prefs[getProfileKey(CONNECTION_PROFILES_ENCRYPTED, profile)]).orEmpty()
         )

--- a/app/src/main/java/com/wdtt/client/TunnelManager.kt
+++ b/app/src/main/java/com/wdtt/client/TunnelManager.kt
@@ -50,6 +50,7 @@ object TunnelManager {
     private var forceRegenerateUA = false 
     private var currentCaptchaMode = "wv" 
     private var currentCaptchaSolveMethod = "auto" 
+    private var staticWireGuardStarted = false
 
     @Volatile
     var isLoggingEnabled = true
@@ -85,6 +86,18 @@ object TunnelManager {
             }
             is TunnelEventParser.Event.Ready -> {
                 updateLog("ready", "[READY] Туннель готов к работе ✓", 2, false)
+                val staticConfig = currentParams?.wireGuardConfig.orEmpty()
+                if (!staticWireGuardStarted && staticConfig.isNotBlank()) {
+                    staticWireGuardStarted = true
+                    config.value = staticConfig
+                    scope.launch(Dispatchers.Main) {
+                        try {
+                            wgHelper?.startTunnel(staticConfig)
+                        } catch (e: Exception) {
+                            updateLog("vpn_start_error", "Ошибка запуска VPN: ${e.readableMessage()}", 99, true)
+                        }
+                    }
+                }
             }
             is TunnelEventParser.Event.Config -> {
                 val configStr = event.config.trim()
@@ -205,6 +218,7 @@ object TunnelManager {
                     forceRegenerateUA = false
                     currentCaptchaMode = params.captchaMode
                     currentCaptchaSolveMethod = params.captchaSolveMethod
+                    staticWireGuardStarted = false
                 }
                 
                 wgHelper = WireGuardHelper(appContext)
@@ -223,7 +237,7 @@ object TunnelManager {
                     running.value = false
                     return@launch
                 }
-                if (params.connectionPassword.isBlank()) {
+                if (!params.isFreeTurn && params.connectionPassword.isBlank()) {
                     updateLog("password_error", "Ошибка: пароль подключения не указан", 99, true)
                     running.value = false
                     return@launch
@@ -269,8 +283,18 @@ object TunnelManager {
                 cmd.add("-device-id")
                 cmd.add(androidId)
 
-                cmd.add("-password")
-                cmd.add(params.connectionPassword)
+                if (params.isFreeTurn) {
+                    cmd.add("-wrap-s")
+                    cmd.add("-obf-profile")
+                    cmd.add(params.obfProfile)
+                    cmd.add("-obf-key")
+                    cmd.add(params.obfKey)
+                    cmd.add("-free-client-id")
+                    cmd.add(params.freeClientId)
+                } else {
+                    cmd.add("-password")
+                    cmd.add(params.connectionPassword)
+                }
 
                 cmd.add("-captcha-mode")
                 cmd.add(params.captchaMode)
@@ -895,5 +919,10 @@ data class TunnelParams(
     val captchaSolveMethod: String = "auto",
     val fingerprint: String = "firefox",
     val clientIds: String = "8202606,6287487",
-    val obfsMode: String = "audio"
+    val obfsMode: String = "audio",
+    val isFreeTurn: Boolean = false,
+    val obfKey: String = "",
+    val obfProfile: String = "rtpopus3",
+    val freeClientId: String = "",
+    val wireGuardConfig: String = ""
 )

--- a/app/src/main/java/com/wdtt/client/TunnelService.kt
+++ b/app/src/main/java/com/wdtt/client/TunnelService.kt
@@ -75,7 +75,12 @@ class TunnelService : Service() {
                     captchaSolveMethod = intent.getStringExtra("captcha_solve_method") ?: "auto",
                     fingerprint = intent.getStringExtra("fingerprint") ?: "firefox",
                     clientIds = intent.getStringExtra("client_ids") ?: "8202606,6287487",
-                    obfsMode = intent.getStringExtra("obfs_mode")?.takeIf { it.isNotBlank() } ?: "audio"
+                    obfsMode = intent.getStringExtra("obfs_mode")?.takeIf { it.isNotBlank() } ?: "audio",
+                    isFreeTurn = intent.getBooleanExtra("free_turn", false),
+                    obfKey = intent.getStringExtra("free_obf_key") ?: "",
+                    obfProfile = intent.getStringExtra("free_obf_profile") ?: "rtpopus3",
+                    freeClientId = intent.getStringExtra("free_client_id") ?: "",
+                    wireGuardConfig = intent.getStringExtra("wireguard_config") ?: ""
                 )
                 startTunnel(params)
             }
@@ -109,25 +114,31 @@ class TunnelService : Service() {
         TunnelManager.scope.launch {
             try {
                 val store = SettingsStore(appContext)
-                val basePeer = store.peer.first()
+                val profile = store.activeConnectionProfile()
+                val basePeer = profile?.peer ?: store.peer.first()
                 val manualPortsEnabled = store.manualPortsEnabled.first()
                 val serverDtlsPort = if (manualPortsEnabled) store.serverDtlsPort.first() else 56000
                 val peerWithPort = if (basePeer.isBlank() || basePeer.contains(":")) basePeer else "$basePeer:$serverDtlsPort"
                 val params = TunnelParams(
                     peer = peerWithPort,
-                    vkHashes = store.vkHashes.first(),
+                    vkHashes = profile?.vkLinks ?: store.vkHashes.first(),
                     secondaryVkHash = store.secondaryVkHash.first(),
-                    workersPerHash = store.workersPerHash.first(),
-                    port = store.listenPort.first(),
+                    workersPerHash = profile?.workers ?: store.workersPerHash.first(),
+                    port = profile?.localPort ?: store.listenPort.first(),
                     sni = store.sni.first(),
-                    connectionPassword = store.connectionPassword.first(),
+                    connectionPassword = profile?.wrapAPassword ?: store.connectionPassword.first(),
                     vkAuthMode = sanitizeVkAuthMode(store.vkAuthMode.first()),
                     captchaMode = sanitizeCaptchaMode(store.captchaMode.first()),
                     captchaSolveMethod = store.captchaSolveMethod.first(),
                     fingerprint = store.selectedFingerprint.first(),
-                    clientIds = store.activeClientIds.first()
+                    clientIds = store.activeClientIds.first(),
+                    isFreeTurn = profile?.mode == ConnectionMode.WRAP_S,
+                    obfKey = profile?.obfKey.orEmpty(),
+                    obfProfile = profile?.obfProfile ?: "rtpopus3",
+                    freeClientId = profile?.clientId.orEmpty(),
+                    wireGuardConfig = profile?.wireGuardConfig.orEmpty()
                 )
-                if (params.peer.isNotEmpty() && params.vkHashes.isNotEmpty()) {
+                if (params.peer.isNotEmpty() && params.vkHashes.isNotEmpty() && (!params.isFreeTurn || profile?.isReady == true)) {
                     launch(Dispatchers.Main) {
                         startTunnel(params)
                     }

--- a/app/src/main/java/com/wdtt/client/VpnWidgetProvider.kt
+++ b/app/src/main/java/com/wdtt/client/VpnWidgetProvider.kt
@@ -138,14 +138,16 @@ class VpnWidgetProvider : AppWidgetProvider() {
 
     private suspend fun buildStartIntent(context: Context): Intent? {
         val store = SettingsStore(context.applicationContext)
-        val basePeer = store.peer.first()
-        val hashes = store.vkHashes.first()
-        val password = store.connectionPassword.first()
-        if (basePeer.isBlank() || hashes.isBlank() || password.isBlank()) return null
+        val profile = store.activeConnectionProfile()
+        val basePeer = profile?.peer ?: store.peer.first()
+        val hashes = profile?.vkLinks ?: store.vkHashes.first()
+        val password = profile?.wrapAPassword ?: store.connectionPassword.first()
+        val isFreeTurn = profile?.mode == ConnectionMode.WRAP_S
+        if (basePeer.isBlank() || hashes.isBlank() || (!isFreeTurn && password.isBlank()) || (isFreeTurn && profile?.isReady != true)) return null
 
         val manualPortsEnabled = store.manualPortsEnabled.first()
         val serverDtlsPort = if (manualPortsEnabled) store.serverDtlsPort.first() else 56000
-        val localPort = if (manualPortsEnabled) store.listenPort.first() else 9000
+        val localPort = profile?.localPort ?: if (manualPortsEnabled) store.listenPort.first() else 9000
         val peerWithPort = if (basePeer.contains(":")) basePeer else "$basePeer:$serverDtlsPort"
 
         return Intent(context, TunnelService::class.java).apply {
@@ -153,7 +155,7 @@ class VpnWidgetProvider : AppWidgetProvider() {
             putExtra("peer", peerWithPort)
             putExtra("vk_hashes", hashes)
             putExtra("secondary_vk_hash", store.secondaryVkHash.first())
-            putExtra("workers_per_hash", store.workersPerHash.first())
+            putExtra("workers_per_hash", profile?.workers ?: store.workersPerHash.first())
             putExtra("port", localPort)
             putExtra("sni", store.sni.first())
             putExtra("connection_password", store.connectionPassword.first())
@@ -164,6 +166,11 @@ class VpnWidgetProvider : AppWidgetProvider() {
             putExtra("fingerprint", store.selectedFingerprint.first())
             putExtra("client_ids", store.activeClientIds.first())
             putExtra("obfs_mode", store.obfsMode.first())
+            putExtra("free_turn", isFreeTurn)
+            putExtra("free_obf_key", profile?.obfKey.orEmpty())
+            putExtra("free_obf_profile", profile?.obfProfile.orEmpty())
+            putExtra("free_client_id", profile?.clientId.orEmpty())
+            putExtra("wireguard_config", profile?.wireGuardConfig.orEmpty())
         }
     }
 

--- a/app/src/main/java/com/wdtt/client/VpnWidgetProvider.kt
+++ b/app/src/main/java/com/wdtt/client/VpnWidgetProvider.kt
@@ -158,7 +158,7 @@ class VpnWidgetProvider : AppWidgetProvider() {
             putExtra("workers_per_hash", profile?.workers ?: store.workersPerHash.first())
             putExtra("port", localPort)
             putExtra("sni", store.sni.first())
-            putExtra("connection_password", store.connectionPassword.first())
+            putExtra("connection_password", password)
             putExtra("protocol", store.protocol.first())
             putExtra("vk_auth_mode", store.vkAuthMode.first())
             putExtra("captcha_mode", store.captchaMode.first())

--- a/app/src/main/java/com/wdtt/client/ui/SettingsTab.kt
+++ b/app/src/main/java/com/wdtt/client/ui/SettingsTab.kt
@@ -48,11 +48,13 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wdtt.client.SettingsStore
+import com.wdtt.client.ConnectionMode
 import com.wdtt.client.ConnectionProfile
 import com.wdtt.client.ConnectionProfileParser
 import com.wdtt.client.TunnelManager
 import com.wdtt.client.TunnelService
 import com.wdtt.client.WDTTColors
+import com.wdtt.client.normalizeConnectionProfileWorkers
 import com.wdtt.client.ui.dialogs.HashesDialog
 import com.wdtt.client.ui.dialogs.SecretsDialog
 import com.wdtt.client.ui.utils.stripVkUrlStatic
@@ -123,6 +125,7 @@ fun SettingsTabContent(context: android.content.Context, scope: kotlinx.coroutin
     var vkHash3 by rememberSaveable { mutableStateOf("") }
     var vkHash4 by rememberSaveable { mutableStateOf("") }
     var workersInput by rememberSaveable { mutableFloatStateOf(18f) }
+    var profileWorkersInput by rememberSaveable { mutableFloatStateOf(18f) }
     var showHashesDialog by rememberSaveable { mutableStateOf(false) }
     var useVKCallsAuth by rememberSaveable { mutableStateOf(true) }
     var obfsMode by rememberSaveable { mutableStateOf("audio") }
@@ -156,13 +159,22 @@ fun SettingsTabContent(context: android.content.Context, scope: kotlinx.coroutin
     var portInput by rememberSaveable { mutableStateOf("9000") }
     var sniInput by rememberSaveable { mutableStateOf("") }
 
-    LaunchedEffect(dynamicMaxWorkers) {
-        if (workersInput > dynamicMaxWorkers) {
+    LaunchedEffect(dynamicMaxWorkers, wdttLinkMode) {
+        if (!wdttLinkMode && workersInput > dynamicMaxWorkers) {
             workersInput = dynamicMaxWorkers
         }
     }
 
-    val currentWorkers = workersInput.coerceIn(WORKERS_PER_GROUP.toFloat(), dynamicMaxWorkers)
+    LaunchedEffect(selectedConnectionProfile?.id, selectedConnectionProfile?.workers) {
+        profileWorkersInput = normalizeConnectionProfileWorkers(selectedConnectionProfile?.workers ?: 18).toFloat()
+    }
+
+    val isProfileWorkersMode = wdttLinkMode && selectedConnectionProfile != null
+    val currentWorkers = if (isProfileWorkersMode) {
+        profileWorkersInput
+    } else {
+        workersInput.coerceIn(WORKERS_PER_GROUP.toFloat(), dynamicMaxWorkers)
+    }
 
     val hashErrors = remember(vkHash1, vkHash2, vkHash3, vkHash4) {
         buildList {
@@ -544,7 +556,7 @@ fun SettingsTabContent(context: android.content.Context, scope: kotlinx.coroutin
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            "Мощность",
+                            if (isProfileWorkersMode) "Потоки конфигурации" else "Мощность",
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.primary,
                             fontWeight = FontWeight.SemiBold
@@ -558,15 +570,30 @@ fun SettingsTabContent(context: android.content.Context, scope: kotlinx.coroutin
 
                     Spacer(Modifier.height(4.dp))
 
-                    val maxWorkers = dynamicMaxWorkers
+                    val maxWorkers = if (isProfileWorkersMode) 27f else dynamicMaxWorkers
                     val minWorkers = WORKERS_PER_GROUP.toFloat()
-                    val currentWorkersVal = roundToGroup(currentWorkers.coerceIn(minWorkers, maxWorkers), maxWorkers)
+                    val currentWorkersVal = roundToGroup(
+                        currentWorkers.coerceIn(minWorkers, maxWorkers),
+                        WORKERS_PER_GROUP.toFloat()
+                    )
 
                     CompactSteppedSlider(
                         value = currentWorkersVal,
                         onValueChange = { raw ->
-                            workersInput = roundToGroup(raw, maxWorkers)
-                            scheduleSave()
+                            if (isProfileWorkersMode) {
+                                val workers = normalizeConnectionProfileWorkers(raw.toInt())
+                                profileWorkersInput = workers.toFloat()
+                                selectedConnectionProfile?.let { profile ->
+                                    saveJob?.cancel()
+                                    saveJob = scope.launch {
+                                        delay(300)
+                                        settingsStore.updateConnectionProfileWorkers(profile.id, workers)
+                                    }
+                                }
+                            } else {
+                                workersInput = roundToGroup(raw, maxWorkers)
+                                scheduleSave()
+                            }
                         },
                         valueRange = minWorkers..maxWorkers,
                         stepSize = WORKERS_PER_GROUP.toFloat(),
@@ -605,25 +632,45 @@ fun SettingsTabContent(context: android.content.Context, scope: kotlinx.coroutin
                     }
 
                     
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Text(
-                            "Маскировка",
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Medium,
-                            modifier = Modifier.weight(1f)
-                        )
-                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            ProtocolChip("Аудио", obfsMode == "audio", enabled = !tunnelRunning) {
-                                obfsMode = "audio"
-                                scope.launch { settingsStore.saveObfsMode("audio") }
-                            }
-                            ProtocolChip("Видео", obfsMode == "video", enabled = !tunnelRunning) {
-                                obfsMode = "video"
-                                scope.launch { settingsStore.saveObfsMode("video") }
+                    if (wdttLinkMode && selectedConnectionProfile?.mode == ConnectionMode.WRAP_S) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                "Маскировка",
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.Medium
+                            )
+                            Text(
+                                selectedConnectionProfile?.obfProfile.orEmpty(),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.primary,
+                                fontWeight = FontWeight.Medium
+                            )
+                        }
+                    } else {
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                "Маскировка",
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.Medium,
+                                modifier = Modifier.weight(1f)
+                            )
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                ProtocolChip("Аудио", obfsMode == "audio", enabled = !tunnelRunning) {
+                                    obfsMode = "audio"
+                                    scope.launch { settingsStore.saveObfsMode("audio") }
+                                }
+                                ProtocolChip("Видео", obfsMode == "video", enabled = !tunnelRunning) {
+                                    obfsMode = "video"
+                                    scope.launch { settingsStore.saveObfsMode("video") }
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/wdtt/client/ui/SettingsTab.kt
+++ b/app/src/main/java/com/wdtt/client/ui/SettingsTab.kt
@@ -418,7 +418,7 @@ fun SettingsTabContent(context: android.content.Context, scope: kotlinx.coroutin
                         value = connectionImportText,
                         onValueChange = { connectionImportText = it.trim() },
                         label = { Text("Ссылка подключения") },
-                        supportingText = { Text("wdtt://, vkturnproxy:// или freeturn://") },
+                        supportingText = { Text("wdtt:// или vkturnproxy://") },
                         minLines = 3,
                         modifier = Modifier.fillMaxWidth()
                     )
@@ -854,7 +854,7 @@ fun SettingsTabContent(context: android.content.Context, scope: kotlinx.coroutin
                                 }
                             }
                             if (connectionProfiles.isEmpty()) {
-                                Text("Добавьте ссылку wdtt://, vkturnproxy:// или freeturn://", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                Text("Добавьте ссылку wdtt:// или vkturnproxy://", color = MaterialTheme.colorScheme.onSurfaceVariant)
                             }
                             connectionProfiles.forEach { profile ->
                                 val selected = profile.id == selectedConnectionProfile?.id

--- a/app/src/main/java/com/wdtt/client/ui/SettingsTab.kt
+++ b/app/src/main/java/com/wdtt/client/ui/SettingsTab.kt
@@ -21,7 +21,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.PowerSettingsNew
 import androidx.compose.material.icons.filled.Stop
@@ -45,6 +48,8 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wdtt.client.SettingsStore
+import com.wdtt.client.ConnectionProfile
+import com.wdtt.client.ConnectionProfileParser
 import com.wdtt.client.TunnelManager
 import com.wdtt.client.TunnelService
 import com.wdtt.client.WDTTColors
@@ -91,7 +96,10 @@ fun SettingsTabContent(context: android.content.Context, scope: kotlinx.coroutin
 
     val activeProfile by settingsStore.activeProfile.collectAsStateWithLifecycle(initialValue = 0)
     val wdttLinkMode by settingsStore.wdttLinkMode.collectAsStateWithLifecycle(initialValue = false)
-    val wdttLink by settingsStore.wdttLink.collectAsStateWithLifecycle(initialValue = "")
+    val connectionProfiles by settingsStore.connectionProfiles.collectAsStateWithLifecycle(initialValue = emptyList())
+    val activeConnectionProfileId by settingsStore.activeConnectionProfileId.collectAsStateWithLifecycle(initialValue = "")
+    val selectedConnectionProfile = connectionProfiles.firstOrNull { it.id == activeConnectionProfileId }
+        ?: connectionProfiles.firstOrNull()
 
     val activeFingerprint by settingsStore.selectedFingerprint.collectAsStateWithLifecycle(initialValue = "firefox")
     val activeClientIds by settingsStore.activeClientIds.collectAsStateWithLifecycle(initialValue = "8202606,6287487")
@@ -125,17 +133,20 @@ fun SettingsTabContent(context: android.content.Context, scope: kotlinx.coroutin
     var manualPortsEnabled by rememberSaveable { mutableStateOf(false) }
     var serverDtlsPortInput by rememberSaveable { mutableStateOf("56000") }
     var serverWgPortInput by rememberSaveable { mutableStateOf("56001") }
+    var showConnectionImport by rememberSaveable { mutableStateOf(false) }
+    var connectionImportText by rememberSaveable { mutableStateOf("") }
+    var connectionImportError by rememberSaveable { mutableStateOf("") }
+    var detailsProfile by remember { mutableStateOf<ConnectionProfile?>(null) }
+    var profileSwitching by remember { mutableStateOf(false) }
 
     val allHashes = remember(vkHash1, vkHash2, vkHash3, vkHash4) { listOf(vkHash1, vkHash2, vkHash3, vkHash4) }
     val uniqueHashes = remember(vkHash1, vkHash2, vkHash3, vkHash4) { allHashes.filter { it.isNotBlank() && it.length >= 16 }.distinct() }
-    val parsedLinkHashes = remember(wdttLink) {
-        if (wdttLink.trim().startsWith("wdtt://")) {
-            val clean = wdttLink.trim().removePrefix("wdtt://")
-            val parts = clean.split(":")
-            if (parts.size >= 6) {
-                parts[5].split(",").filter { stripVkUrlStatic(it).isNotBlank() }
-            } else emptyList()
-        } else emptyList()
+    val parsedLinkHashes = remember(selectedConnectionProfile) {
+        selectedConnectionProfile?.vkLinks
+            ?.split(Regex("[,\\s\\n]+"))
+            ?.map(::stripVkUrlStatic)
+            ?.filter { it.isNotBlank() }
+            .orEmpty()
     }
     val filledHashCount = remember(vkHash1, vkHash2, vkHash3, vkHash4, wdttLinkMode, parsedLinkHashes) { 
         if (wdttLinkMode) parsedLinkHashes.size else uniqueHashes.size 
@@ -268,14 +279,14 @@ fun SettingsTabContent(context: android.content.Context, scope: kotlinx.coroutin
 
     val isPeerValid = peerInput.isNotBlank() && !peerInput.contains(":")
     val isHashesValid = combinedHashes.isNotBlank()
-    val isLinkValid = wdttLink.trim().startsWith("wdtt://") && wdttLink.trim().split(":").size >= 6 && wdttLink.trim().split(":")[5].isNotBlank()
+    val isLinkValid = selectedConnectionProfile?.isReady == true
     val isManualValid = isPeerValid && isHashesValid && savedConnectionPassword.isNotBlank() && !hasInputHashErrors
     val isValid = if (wdttLinkMode) isLinkValid else isManualValid
     val effectiveServerDtlsPort = if (manualPortsEnabled) serverDtlsPortInput.toIntOrNull()?.coerceIn(1, 65535) ?: 56000 else 56000
     val effectiveLocalPort = if (manualPortsEnabled) portInput.toIntOrNull()?.coerceIn(1, 65535) ?: 9000 else 9000
     var pendingStartAfterVpnPermission by remember { mutableStateOf(false) }
 
-    fun startTunnelService() {
+    fun startTunnelService(profileOverride: ConnectionProfile? = null) {
         val effectiveVkAuthMode = if (useVKCallsAuth) "vkcalls" else "legacy"
         val effectiveCaptchaMode = if (autoCaptchaEnabled) "auto" else if (useWVCaptcha) "wv" else "rjs"
         val effectiveCaptchaSolveMethod = if (!autoCaptchaEnabled && effectiveCaptchaMode == "wv" && isManualMode) "manual" else "auto"
@@ -290,33 +301,18 @@ fun SettingsTabContent(context: android.content.Context, scope: kotlinx.coroutin
             settingsStore.saveCaptchaSolveMethod(effectiveCaptchaSolveMethod)
         }
 
-        var finalPeer = "$peerInput:$effectiveServerDtlsPort"
-        var finalHashes = combinedHashes
-        var finalLocalPort = effectiveLocalPort
-        var finalPassword = savedConnectionPassword
-
-        if (wdttLinkMode && wdttLink.trim().startsWith("wdtt://")) {
-            val clean = wdttLink.trim().removePrefix("wdtt://")
-            val parts = clean.split(":")
-            if (parts.size >= 5) {
-                val ip = parts[0]
-                val dtls = parts[1].toIntOrNull() ?: 56000
-                finalLocalPort = parts[3].toIntOrNull() ?: 9000
-                finalPassword = parts[4]
-                val hash = if (parts.size >= 6) parts[5] else ""
-                
-                finalPeer = "$ip:$dtls"
-                val rawHash = stripVkUrlStatic(hash)
-                finalHashes = if (rawHash.isNotBlank()) rawHash else normalizeHashes(hash)
-            }
-        }
+        val connectionProfile = profileOverride ?: if (wdttLinkMode) selectedConnectionProfile else null
+        val finalPeer = connectionProfile?.peer ?: "$peerInput:$effectiveServerDtlsPort"
+        val finalHashes = connectionProfile?.vkLinks ?: combinedHashes
+        val finalLocalPort = connectionProfile?.localPort ?: effectiveLocalPort
+        val finalPassword = connectionProfile?.wrapAPassword ?: savedConnectionPassword
 
         val intent = Intent(context, TunnelService::class.java).apply {
             action = "START"
             putExtra("peer", finalPeer)
             putExtra("vk_hashes", finalHashes)
             putExtra("secondary_vk_hash", "")
-            putExtra("workers_per_hash", workersInput.toInt())
+            putExtra("workers_per_hash", connectionProfile?.workers ?: workersInput.toInt())
             putExtra("port", finalLocalPort)
             putExtra("sni", sniInput)
             putExtra("connection_password", finalPassword)
@@ -326,6 +322,11 @@ fun SettingsTabContent(context: android.content.Context, scope: kotlinx.coroutin
             putExtra("fingerprint", activeFingerprint)
             putExtra("client_ids", activeClientIds)
             putExtra("obfs_mode", obfsMode)
+            putExtra("free_turn", connectionProfile?.mode?.name == "WRAP_S")
+            putExtra("free_obf_key", connectionProfile?.obfKey.orEmpty())
+            putExtra("free_obf_profile", connectionProfile?.obfProfile.orEmpty())
+            putExtra("free_client_id", connectionProfile?.clientId.orEmpty())
+            putExtra("wireguard_config", connectionProfile?.wireGuardConfig.orEmpty())
         }
         if (Build.VERSION.SDK_INT >= 26) context.startForegroundService(intent)
         else context.startService(intent)
@@ -392,6 +393,71 @@ fun SettingsTabContent(context: android.content.Context, scope: kotlinx.coroutin
                 }
             },
             onDismiss = { showHashesDialog = false }
+        )
+    }
+
+    if (showConnectionImport) {
+        AlertDialog(
+            onDismissRequest = { showConnectionImport = false },
+            title = { Text("Импорт конфига") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = connectionImportText,
+                        onValueChange = { connectionImportText = it.trim() },
+                        label = { Text("Ссылка подключения") },
+                        supportingText = { Text("wdtt://, vkturnproxy:// или freeturn://") },
+                        minLines = 3,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    if (connectionImportError.isNotBlank()) {
+                        Text(connectionImportError, color = MaterialTheme.colorScheme.error)
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    val imported = runCatching { ConnectionProfileParser.parse(connectionImportText) }
+                    imported.onSuccess { profile ->
+                        scope.launch { settingsStore.saveConnectionProfile(profile) }
+                        connectionImportError = ""
+                        connectionImportText = ""
+                        showConnectionImport = false
+                    }.onFailure { error -> connectionImportError = error.message ?: "Не удалось импортировать ссылку" }
+                }) { Text("Импортировать") }
+            },
+            dismissButton = { TextButton(onClick = { showConnectionImport = false }) { Text("Отмена") } }
+        )
+    }
+
+    detailsProfile?.let { profile ->
+        AlertDialog(
+            onDismissRequest = { detailsProfile = null },
+            title = { Text(profile.name) },
+            text = {
+                Column(modifier = Modifier.verticalScroll(rememberScrollState()), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text("Режим: ${profile.mode.label}")
+                    Text("Сервер: ${profile.peer}")
+                    Text("VK call link: ${profile.vkLinks}")
+                    Text("Локальный порт: ${profile.localPort}")
+                    Text("Потоков: ${profile.workers}")
+                    if (profile.mode.name == "WRAP_A") {
+                        Text("Пароль: ${profile.wrapAPassword}")
+                    } else {
+                        Text("OBF profile: ${profile.obfProfile}")
+                        Text("OBF key: ${profile.obfKey}")
+                        Text("Client ID: ${profile.clientId}")
+                        Text("WireGuard:\n${profile.wireGuardConfig.ifBlank { "Конфиг не указан" }}")
+                    }
+                }
+            },
+            confirmButton = { TextButton(onClick = { detailsProfile = null }) { Text("Готово") } },
+            dismissButton = {
+                TextButton(onClick = {
+                    scope.launch { settingsStore.removeConnectionProfile(profile.id) }
+                    detailsProfile = null
+                }) { Icon(Icons.Default.Delete, contentDescription = "Удалить конфиг") }
+            }
         )
     }
 
@@ -733,24 +799,57 @@ fun SettingsTabContent(context: android.content.Context, scope: kotlinx.coroutin
                     }
 
                     if (wdttLinkMode) {
-                        Column {
-                            var linkText by remember(wdttLink) { mutableStateOf(wdttLink) }
-                            OutlinedTextField(
-                                value = linkText,
-                                onValueChange = {
-                                    val cleaned = it.filter { c -> !c.isWhitespace() }
-                                    linkText = cleaned
-                                    scope.launch { settingsStore.saveWdttLink(cleaned) }
-                                },
-                                label = { Text("Ссылка wdtt://") },
-                                placeholder = { Text("Ссылка wdtt://") },
-                                modifier = Modifier.fillMaxWidth(),
-                                shape = RoundedCornerShape(16.dp),
-                                colors = OutlinedTextFieldDefaults.colors(
-                                    focusedBorderColor = MaterialTheme.colorScheme.primary,
-                                    unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
-                                )
-                            )
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text("Конфиги", style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium, modifier = Modifier.weight(1f))
+                                IconButton(onClick = { showConnectionImport = true }, enabled = !tunnelRunning) {
+                                    Icon(Icons.Default.Add, contentDescription = "Добавить конфиг")
+                                }
+                            }
+                            if (connectionProfiles.isEmpty()) {
+                                Text("Добавьте ссылку wdtt://, vkturnproxy:// или freeturn://", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                            connectionProfiles.forEach { profile ->
+                                val selected = profile.id == selectedConnectionProfile?.id
+                                Surface(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    shape = RoundedCornerShape(12.dp),
+                                    color = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant,
+                                    onClick = {
+                                        if (profile.id != selectedConnectionProfile?.id && !profileSwitching) {
+                                            scope.launch {
+                                                profileSwitching = true
+                                                try {
+                                                    settingsStore.selectConnectionProfile(profile.id)
+                                                    if (tunnelRunning && profile.isReady) {
+                                                        TunnelManager.stopAndWait()
+                                                        startTunnelService(profile)
+                                                    }
+                                                } finally {
+                                                    profileSwitching = false
+                                                }
+                                            }
+                                        }
+                                    }
+                                ) {
+                                    Row(
+                                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Column(modifier = Modifier.weight(1f)) {
+                                            Text(profile.name, maxLines = 1, fontWeight = FontWeight.Medium)
+                                            Text(
+                                                "${profile.mode.label}${if (profile.mode.name == "WRAP_S") " · ${profile.obfProfile}" else ""}",
+                                                style = MaterialTheme.typography.labelMedium,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        }
+                                        IconButton(onClick = { detailsProfile = profile }) {
+                                            Icon(Icons.Default.Info, contentDescription = "Параметры конфига")
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Добавлена поддержка [samosvalishe/free-turn-proxy](https://github.com/samosvalishe/free-turn-proxy) через режим SRTP-WRAP-S.
* импорт ссылок vkturnproxy:// и freeturn://;
* сохранённые профили подключений для SRTP-WRAP-A и SRTP-WRAP-S;
* поддержка OBF-профилей rtpopus, rtpopus2, rtpopus3;
* передача Client ID и статического WireGuard-конфига для Free Turn;
* отдельные настройки потоков для каждого импортированного профиля;
* отображение OBF-профиля SRTP-WRAP-S в интерфейсе.